### PR TITLE
Refine PB-GSE gating pipeline and inference modules

### DIFF
--- a/pb_gse/models/gating.py
+++ b/pb_gse/models/gating.py
@@ -1,341 +1,341 @@
-"""
-Gating network and PAC-Bayes bound optimization
-"""
+"""Utilities for learning the PB-GSE gating network."""
+
+from __future__ import annotations
+
+import math
+from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-import numpy as np
-from typing import Dict, List, Tuple, Optional
-import math
 
 
-class GatingNetwork(nn.Module):
-    """MLP-based gating network for ensemble weighting"""
+TensorOrList = Union[torch.Tensor, List[torch.Tensor]]
+
+
+def _activation_fn(name: str) -> nn.Module:
+    """Return the activation module specified by ``name``."""
+
+    name = name.lower()
+    if name == "relu":
+        return nn.ReLU()
+    if name == "gelu":
+        return nn.GELU()
+    if name == "tanh":
+        return nn.Tanh()
+    raise ValueError(f"Unsupported activation: {name}")
+
+
+class FeatureExtractor:
+    """Create input features for the gating network.
+
+    The extractor is designed to work both during training (where group labels are
+    available) and at test time (where they are typically unknown).  Features are
+    computed from the calibrated model probabilities and optionally include
+    aggregated statistics such as entropy, disagreement and soft group masses.
+    """
+
+    def __init__(self, config: Dict, group_info: Optional[Dict] = None):
+        self.config = config.get("features", {})
+        self.group_info = group_info or {}
+        self.use_group_onehot = bool(self.config.get("use_group_onehot", False))
+
+        group_to_classes = self.group_info.get("group_to_classes", {})
+        processed: Dict[int, torch.Tensor] = {}
+        for group_id, class_list in group_to_classes.items():
+            if not class_list:
+                continue
+            indices = torch.tensor(sorted(int(cls) for cls in class_list), dtype=torch.long)
+            processed[int(group_id)] = indices
+        self.group_class_indices = processed
+        self.num_groups = max(processed.keys(), default=-1) + 1
+
+    def _stack_probs(self, model_probs: TensorOrList) -> torch.Tensor:
+        if isinstance(model_probs, list):
+            return torch.stack(model_probs, dim=1)
+        if model_probs.dim() == 2:
+            # [B, C] for a single model – treat as ensemble of size 1
+            return model_probs.unsqueeze(1)
+        if model_probs.dim() == 3:
+            return model_probs
+        raise ValueError("model_probs must have shape [B, C] or [B, M, C]")
+
+    def extract(
+        self,
+        model_probs: TensorOrList,
+        group_onehot: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Return gating features for the provided probabilities."""
+
+        stacked = self._stack_probs(model_probs)  # [B, M, C]
+        batch_size, num_models, num_classes = stacked.shape
+        device = stacked.device
+        features: List[torch.Tensor] = []
+
+        if self.config.get("use_probs", True):
+            features.append(stacked.reshape(batch_size, num_models * num_classes))
+
+        if self.config.get("use_entropy", True):
+            entropy = -torch.sum(stacked * (stacked.clamp_min(1e-12).log()), dim=-1)
+            features.append(entropy)
+
+        if self.config.get("use_max_prob", True):
+            max_prob = torch.max(stacked, dim=-1).values
+            features.append(max_prob)
+
+        if self.config.get("use_disagreement", True) and num_models > 1:
+            variance = torch.var(stacked, dim=1)
+            features.append(variance.mean(dim=-1, keepdim=True))
+
+        if self.config.get("use_soft_group_mass", True) and self.group_class_indices:
+            group_masses: List[torch.Tensor] = []
+            for group_id in range(self.num_groups):
+                class_indices = self.group_class_indices.get(group_id)
+                if class_indices is None:
+                    continue
+                indices = class_indices.to(device)
+                mass = stacked.index_select(-1, indices).sum(dim=-1)
+                group_masses.append(mass)
+            if group_masses:
+                features.append(torch.cat(group_masses, dim=1))
+
+        if self.use_group_onehot:
+            if group_onehot is None:
+                if self.num_groups <= 0:
+                    raise ValueError(
+                        "group_onehot requested but group information is unavailable"
+                    )
+                group_onehot = torch.zeros(batch_size, self.num_groups, device=device)
+            features.append(group_onehot.float())
+
+        if not features:
+            raise ValueError("At least one feature must be enabled for the gating network")
+
+        return torch.cat(features, dim=1)
+
+
+class FeedForwardArchitecture(nn.Module):
+    """Simple feed-forward network used by the gating model."""
+
+    def __init__(
+        self,
+        dims: Sequence[int],
+        activation: str = "relu",
+        dropout: float = 0.0,
+    ):
+        super().__init__()
+        if len(dims) < 2:
+            raise ValueError("dims must contain at least input and output size")
+
+        self.layers = nn.ModuleList(
+            nn.Linear(in_dim, out_dim) for in_dim, out_dim in zip(dims[:-1], dims[1:])
+        )
+        self.activation = _activation_fn(activation)
+        self.dropout_layers = nn.ModuleList(
+            nn.Dropout(dropout) for _ in range(max(len(dims) - 2, 0))
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        h = x
+        for idx, layer in enumerate(self.layers):
+            h = layer(h)
+            if idx < len(self.layers) - 1:
+                h = self.activation(h)
+                if self.dropout_layers:
+                    h = self.dropout_layers[idx](h)
+        return F.softmax(h, dim=-1)
+
+    def forward_with_params(
+        self, x: torch.Tensor, params: Sequence[Tuple[torch.Tensor, torch.Tensor]]
+    ) -> torch.Tensor:
+        if len(params) != len(self.layers):
+            raise ValueError("Number of parameter tuples does not match architecture")
+
+        h = x
+        for idx, (weight, bias) in enumerate(params):
+            h = F.linear(h, weight, bias)
+            if idx < len(params) - 1:
+                h = self.activation(h)
+                if self.dropout_layers:
+                    h = self.dropout_layers[idx](h)
+        return F.softmax(h, dim=-1)
+
+
+class GaussianPosterior(nn.Module):
+    """Diagonal Gaussian posterior for the gating network parameters."""
+
+    def __init__(self, layer_dims: Sequence[Tuple[int, int]], initial_std: float = 0.1):
+        super().__init__()
+        if initial_std <= 0:
+            raise ValueError("initial_std must be positive")
+
+        self.mu_weights = nn.ParameterList()
+        self.mu_biases = nn.ParameterList()
+        self.log_sigma_weights = nn.ParameterList()
+        self.log_sigma_biases = nn.ParameterList()
+
+        for in_dim, out_dim in layer_dims:
+            weight_mu = nn.Parameter(torch.empty(out_dim, in_dim))
+            nn.init.kaiming_uniform_(weight_mu, a=math.sqrt(5))
+            bias_mu = nn.Parameter(torch.zeros(out_dim))
+
+            weight_log_sigma = nn.Parameter(
+                torch.full((out_dim, in_dim), math.log(initial_std))
+            )
+            bias_log_sigma = nn.Parameter(torch.full((out_dim,), math.log(initial_std)))
+
+            self.mu_weights.append(weight_mu)
+            self.mu_biases.append(bias_mu)
+            self.log_sigma_weights.append(weight_log_sigma)
+            self.log_sigma_biases.append(bias_log_sigma)
+
+    def sample(
+        self, sample: bool = True
+    ) -> List[Tuple[torch.Tensor, torch.Tensor]]:
+        params: List[Tuple[torch.Tensor, torch.Tensor]] = []
+
+        for mu_w, mu_b, log_sigma_w, log_sigma_b in zip(
+            self.mu_weights,
+            self.mu_biases,
+            self.log_sigma_weights,
+            self.log_sigma_biases,
+        ):
+            if sample:
+                eps_w = torch.randn_like(mu_w)
+                eps_b = torch.randn_like(mu_b)
+                weight = mu_w + torch.exp(log_sigma_w) * eps_w
+                bias = mu_b + torch.exp(log_sigma_b) * eps_b
+            else:
+                weight = mu_w
+                bias = mu_b
+            params.append((weight, bias))
+
+        return params
+
+    def kl_divergence(self, prior_std: float) -> torch.Tensor:
+        if prior_std <= 0:
+            raise ValueError("prior_std must be positive")
+
+        prior_var = prior_std**2
+        log_prior_std = math.log(prior_std)
+        kl = torch.tensor(0.0, device=self.mu_weights[0].device)
+
+        for mu_w, mu_b, log_sigma_w, log_sigma_b in zip(
+            self.mu_weights,
+            self.mu_biases,
+            self.log_sigma_weights,
+            self.log_sigma_biases,
+        ):
+            sigma_w = torch.exp(log_sigma_w)
+            sigma_b = torch.exp(log_sigma_b)
+
+            kl += torch.sum(
+                log_prior_std - log_sigma_w
+                + 0.5 * ((sigma_w.pow(2) + mu_w.pow(2)) / prior_var - 1.0)
+            )
+            kl += torch.sum(
+                log_prior_std - log_sigma_b
+                + 0.5 * ((sigma_b.pow(2) + mu_b.pow(2)) / prior_var - 1.0)
+            )
+
+        return kl
+
+
+class PACBayesGating(nn.Module):
+    """Gating network optimised via a PAC-Bayes objective."""
 
     def __init__(
         self,
         input_dim: int,
         num_models: int,
-        hidden_dims: List[int] = [128, 64],
-        dropout: float = 0.1,
-        activation: str = "relu",
+        config: Dict,
+        group_info: Optional[Dict] = None,
     ):
         super().__init__()
 
-        self.input_dim = input_dim
+        if input_dim <= 0:
+            raise ValueError("input_dim must be positive")
+        if num_models <= 0:
+            raise ValueError("num_models must be positive")
+
         self.num_models = num_models
+        self.config = config
+        self.feature_extractor = FeatureExtractor(config, group_info)
 
-        # Build MLP layers
-        layers = []
-        prev_dim = input_dim
+        network_cfg = config.get("network", {})
+        hidden_dims = list(network_cfg.get("hidden_dims", []))
+        dims = [input_dim] + hidden_dims + [num_models]
+        dropout = float(network_cfg.get("dropout", 0.0))
+        activation = network_cfg.get("activation", "relu")
 
-        for hidden_dim in hidden_dims:
-            layers.extend(
-                [
-                    nn.Linear(prev_dim, hidden_dim),
-                    nn.BatchNorm1d(hidden_dim),
-                    self._get_activation(activation),
-                    nn.Dropout(dropout),
-                ]
-            )
-            prev_dim = hidden_dim
+        self.architecture = FeedForwardArchitecture(dims, activation, dropout)
+        self.pac_bayes_cfg = config.get("pac_bayes", {})
+        self.method = self.pac_bayes_cfg.get("method", "deterministic").lower()
 
-        # Output layer
-        layers.append(nn.Linear(prev_dim, num_models))
-
-        self.network = nn.Sequential(*layers)
-
-    def _get_activation(self, activation: str) -> nn.Module:
-        if activation == "relu":
-            return nn.ReLU()
-        elif activation == "gelu":
-            return nn.GELU()
-        elif activation == "tanh":
-            return nn.Tanh()
-        else:
-            raise ValueError(f"Unsupported activation: {activation}")
-
-    def forward(self, x):
-        """Forward pass returning softmax weights"""
-        logits = self.network(x)
-        return F.softmax(logits, dim=1)
-
-
-class FeatureExtractor:
-    """Extract features for gating network input"""
-
-    def __init__(self, config: Dict, group_info: Optional[Dict] = None):
-        self.config = config["features"]
-        self.group_info = group_info
-
-    def extract(
-        self,
-        model_probs: List[torch.Tensor],
-        group_onehot: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
-        """Extract features from model predictions"""
-        features = []
-
-        # Concatenate all model probabilities
-        if self.config.get("use_probs", True):
-            concat_probs = torch.cat(model_probs, dim=1)  # [batch, M*C]
-            features.append(concat_probs)
-
-        # Entropy of each model
-        if self.config.get("use_entropy", True):
-            entropies = []
-            for probs in model_probs:
-                entropy = -torch.sum(
-                    probs * torch.log(probs + 1e-8), dim=1, keepdim=True
-                )
-                entropies.append(entropy)
-            entropy_features = torch.cat(entropies, dim=1)  # [batch, M]
-            features.append(entropy_features)
-
-        # Max probability of each model
-        if self.config.get("use_max_prob", True):
-            max_probs = []
-            for probs in model_probs:
-                max_prob = torch.max(probs, dim=1, keepdim=True)[0]
-                max_probs.append(max_prob)
-            max_prob_features = torch.cat(max_probs, dim=1)  # [batch, M]
-            features.append(max_prob_features)
-
-        # Disagreement between models (variance)
-        if self.config.get("use_disagreement", True):
-            if len(model_probs) > 1:
-                stacked_probs = torch.stack(model_probs, dim=1)  # [batch, M, C]
-                disagreement = torch.var(stacked_probs, dim=1)  # [batch, C]
-                disagreement_scalar = torch.mean(
-                    disagreement, dim=1, keepdim=True
-                )  # [batch, 1]
-                features.append(disagreement_scalar)
-
-        # Soft group-mass features: g_mass^(m)(x; k) = Σ_{y∈G_k} p_y^(m)(x)
-        if self.config.get("use_soft_group_mass", True):
-            group_masses = []
-            for probs in model_probs:
-                # Assume we have group_info accessible
-                if hasattr(self, "group_info") and self.group_info is not None:
-                    num_groups = len(
-                        self.group_info.get("group_to_classes", {0: [], 1: []})
-                    )
-                    mass_features = torch.zeros(
-                        probs.size(0), num_groups, device=probs.device
-                    )
-
-                    for group_id, class_list in self.group_info[
-                        "group_to_classes"
-                    ].items():
-                        if class_list:  # Check if group has classes
-                            class_indices = torch.tensor(
-                                class_list, device=probs.device
-                            )
-                            mass_features[:, group_id] = torch.sum(
-                                probs[:, class_indices], dim=1
-                            )
-
-                    group_masses.append(mass_features)
-
-            if group_masses:
-                concat_masses = torch.cat(group_masses, dim=1)  # [batch, M*K]
-                features.append(concat_masses)
-
-        # Group one-hot encoding (only for training, not inference)
-        if self.config.get("use_group_onehot", True) and group_onehot is not None:
-            features.append(group_onehot)
-
-        return torch.cat(features, dim=1)
-
-
-class GaussianPosterior(nn.Module):
-    """Gaussian posterior Q = N(μ, σ²I) for PAC-Bayes"""
-
-    def __init__(self, param_dim: int, initial_std: float = 0.1):
-        super().__init__()
-        self.param_dim = param_dim
-        self.mu = nn.Parameter(torch.zeros(param_dim))
-        self.log_sigma = nn.Parameter(torch.log(torch.ones(param_dim) * initial_std))
+        if self.method == "gaussian":
+            layer_dims = list(zip(dims[:-1], dims[1:]))
+            init_std = float(self.pac_bayes_cfg.get("posterior_std_init", 0.1))
+            self.posterior = GaussianPosterior(layer_dims, init_std)
+            for param in self.architecture.parameters():
+                param.requires_grad_(False)
+        elif self.method != "deterministic":
+            raise ValueError("pac_bayes.method must be either 'deterministic' or 'gaussian'")
 
     @property
-    def sigma(self):
-        return torch.exp(self.log_sigma)
+    def is_gaussian(self) -> bool:
+        return self.method == "gaussian"
 
-    def sample(self, num_samples: int = 1):
-        """Sample parameters from posterior"""
-        if num_samples == 1:
-            epsilon = torch.randn_like(self.mu)
-            return self.mu + self.sigma * epsilon
-        else:
-            epsilon = torch.randn(num_samples, self.param_dim).to(self.mu.device)
-            return self.mu.unsqueeze(0) + self.sigma.unsqueeze(0) * epsilon
-
-    def kl_divergence(self, prior_std: float = 1.0):
-        """KL divergence KL(Q||Π) where Π = N(0, σ₀²I)"""
-        prior_var = prior_std**2
-        posterior_var = self.sigma**2
-
-        kl = 0.5 * torch.sum(
-            posterior_var / prior_var
-            + self.mu**2 / prior_var
-            - 1
-            - torch.log(posterior_var / prior_var)
-        )
-        return kl
-
-
-class PACBayesGating(nn.Module):
-    """PAC-Bayes Gating with bound optimization"""
-
-    def __init__(self, input_dim: int, num_models: int, config: Dict):
-        super().__init__()
-
-        self.input_dim = input_dim
-        self.num_models = num_models
-        self.config = config["pac_bayes"]
-
-        # Feature extractor
-        self.feature_extractor = FeatureExtractor(config)
-
-        if self.config["method"] == "gaussian":
-            # Gaussian posterior for parameters
-            gating_config = config["network"]
-            hidden_dims = gating_config["hidden_dims"]
-
-            # Calculate total parameter dimension
-            total_params = input_dim * hidden_dims[0]
-            for i in range(len(hidden_dims) - 1):
-                total_params += hidden_dims[i] * hidden_dims[i + 1]
-            total_params += hidden_dims[-1] * num_models
-            # Add bias terms
-            total_params += sum(hidden_dims) + num_models
-
-            self.posterior = GaussianPosterior(
-                total_params, self.config["posterior_std_init"]
-            )
-
-            # Store network structure for parameter reconstruction
-            self.layer_shapes = []
-            prev_dim = input_dim
-            for hidden_dim in hidden_dims:
-                self.layer_shapes.append((prev_dim, hidden_dim))
-                prev_dim = hidden_dim
-            self.layer_shapes.append((prev_dim, num_models))
-
-        else:
-            # Deterministic gating network
-            self.gating_net = GatingNetwork(
-                input_dim,
-                num_models,
-                config["network"]["hidden_dims"],
-                config["network"]["dropout"],
-                config["network"]["activation"],
-            )
-
-    def _reconstruct_network_params(
-        self, flat_params: torch.Tensor
-    ) -> List[Tuple[torch.Tensor, torch.Tensor]]:
-        """Reconstruct network weights and biases from flattened parameters"""
-        params = []
-        start_idx = 0
-
-        for in_dim, out_dim in self.layer_shapes:
-            # Weight matrix
-            weight_size = in_dim * out_dim
-            weight = flat_params[start_idx : start_idx + weight_size].view(
-                out_dim, in_dim
-            )
-            start_idx += weight_size
-
-            # Bias vector
-            bias = flat_params[start_idx : start_idx + out_dim]
-            start_idx += out_dim
-
-            params.append((weight, bias))
-
-        return params
-
-    def _forward_with_params(
-        self, x: torch.Tensor, params: List[Tuple[torch.Tensor, torch.Tensor]]
-    ) -> torch.Tensor:
-        """Forward pass with given parameters"""
-        h = x
-        for i, (weight, bias) in enumerate(params):
-            h = F.linear(h, weight, bias)
-            if i < len(params) - 1:  # Not the last layer
-                h = F.relu(h)
-        return F.softmax(h, dim=1)
-
-    def forward(self, features: torch.Tensor, num_samples: int = 1) -> torch.Tensor:
-        """Forward pass through gating network"""
-        if self.config["method"] == "gaussian":
-            if num_samples == 1:
-                # Single sample
-                sampled_params = self.posterior.sample()
-                network_params = self._reconstruct_network_params(sampled_params)
-                return self._forward_with_params(features, network_params)
-            else:
-                # Multiple samples for Monte Carlo estimation
-                sampled_params = self.posterior.sample(num_samples)
-                outputs = []
-                for i in range(num_samples):
-                    network_params = self._reconstruct_network_params(sampled_params[i])
-                    output = self._forward_with_params(features, network_params)
-                    outputs.append(output)
-                return torch.stack(outputs, dim=0).mean(dim=0)
-        else:
-            # Deterministic forward
-            return self.gating_net(features)
+    def forward(self, features: torch.Tensor, sample: bool = True) -> torch.Tensor:
+        if self.is_gaussian:
+            params = self.posterior.sample(sample=sample)
+            return self.architecture.forward_with_params(features, params)
+        return self.architecture(features)
 
     def compute_ensemble_probs(
-        self, model_probs: List[torch.Tensor], gating_weights: torch.Tensor
+        self, model_probs: TensorOrList, gating_weights: torch.Tensor
     ) -> torch.Tensor:
-        """Compute ensemble probabilities p_Q_θ(x) = Σ_m w_m(x) p^{(m)}(x)"""
-        ensemble_probs = torch.zeros_like(model_probs[0])
+        stacked = model_probs
+        if isinstance(model_probs, list):
+            stacked = torch.stack(model_probs, dim=1)
+        if stacked.dim() != 3:
+            raise ValueError("model_probs must have shape [B, M, C]")
+        if stacked.size(1) != gating_weights.size(1):
+            raise ValueError("Number of models in probabilities and weights mismatch")
 
-        for m, probs in enumerate(model_probs):
-            ensemble_probs += gating_weights[:, m : m + 1] * probs
-
-        return ensemble_probs
+        return torch.sum(gating_weights.unsqueeze(-1) * stacked, dim=1)
 
     def pac_bayes_bound(
         self,
-        empirical_loss: torch.Tensor,
+        empirical_risk: torch.Tensor,
         n_samples: int,
-        delta: float = 0.05,
-        L_alpha: float = None,
+        delta: float,
+        L_alpha: float,
     ) -> torch.Tensor:
-        """Compute PAC-Bayes bound with proper L_α scaling (Formula 7)"""
-        if self.config["method"] == "gaussian":
-            # KL divergence term
-            prior_std = self.config["prior_std"]
-            kl_div = self.posterior.kl_divergence(prior_std)
+        if n_samples <= 0:
+            raise ValueError("n_samples must be positive")
+        if not 0 < delta < 1:
+            raise ValueError("delta must be in (0, 1)")
+        if L_alpha <= 0:
+            raise ValueError("L_alpha must be positive")
 
-            # Get L_α for proper scaling
-            if L_alpha is None:
-                # Fallback estimation: L_α ≈ max{c, K} + c where K=num_groups
-                c = self.config.get("rejection_cost", 0.1)
-                K = self.config.get("num_groups", 2)
-                L_alpha = max(c, K) + c
+        if self.is_gaussian:
+            prior_std = float(self.pac_bayes_cfg.get("prior_std", 1.0))
+            kl = self.posterior.kl_divergence(prior_std)
+            kl_weight = float(self.config.get("kl_weight", 1.0))
+            kl = kl * kl_weight
+            denominator = 2.0 * max(n_samples - 1, 1)
+            complexity = (kl + math.log(2.0 * n_samples / delta)) / denominator
+            return empirical_risk + L_alpha * torch.sqrt(complexity)
 
-            # PAC-Bayes bound (Formula 7): empirical + L_α * sqrt((KL + log(2n/δ)) / (2(n-1)))
-            bound = empirical_loss + L_alpha * torch.sqrt(
-                (kl_div + math.log(2 * n_samples / delta)) / (2 * (n_samples - 1))
-            )
-        else:
-            # Deterministic case: use L2 regularization as KL surrogate
-            l2_reg = 0
-            for param in self.gating_net.parameters():
-                l2_reg += torch.sum(param**2)
-
-            bound = empirical_loss + self.config.get("l2_weight", 0.01) * l2_reg
-
-        return bound
+        l2_weight = float(self.config.get("l2_weight", 0.0))
+        if l2_weight == 0.0:
+            return empirical_risk
+        reg = sum(param.pow(2).sum() for param in self.architecture.parameters())
+        return empirical_risk + l2_weight * reg
 
 
 class BalancedLinearLoss:
-    """Balanced linear loss for PAC-Bayes optimization (Formula 6)"""
+    """Balanced linear loss used in the PAC-Bayes objective."""
 
     def __init__(
         self,
@@ -344,88 +344,80 @@ class BalancedLinearLoss:
         rejection_cost: float,
         group_info: Dict,
     ):
-        self.alpha = alpha
-        self.mu = mu
-        self.rejection_cost = rejection_cost
-        self.group_info = group_info
-        self.class_to_group = group_info["class_to_group"]
+        if rejection_cost < 0:
+            raise ValueError("rejection_cost must be non-negative")
 
-        # Precompute L_α for normalization: L_α = max{c, Σ_k 1/α_k} + c
-        alpha_sum = sum(1.0 / alpha_k for alpha_k in alpha.values())
-        self.L_alpha = max(rejection_cost, alpha_sum) + rejection_cost
+        class_to_group_map = group_info.get("class_to_group", {})
+        if not class_to_group_map:
+            raise ValueError("group_info must contain class_to_group mapping")
+
+        items = sorted((int(cls), int(group)) for cls, group in class_to_group_map.items())
+        num_classes = items[-1][0] + 1
+        self.class_to_group = torch.full((num_classes,), -1, dtype=torch.long)
+        for cls, group in items:
+            self.class_to_group[cls] = group
+
+        group_ids = sorted({int(g) for g in alpha.keys()})
+        self.alpha = torch.tensor([float(alpha[g]) for g in group_ids], dtype=torch.float32)
+        self.mu = torch.tensor([float(mu[g]) for g in group_ids], dtype=torch.float32)
+        if torch.any(self.alpha <= 0):
+            raise ValueError("alpha values must be positive")
+
+        self.rejection_cost = float(rejection_cost)
+        self.num_groups = len(group_ids)
+        inv_alpha_sum = torch.sum(1.0 / self.alpha).item()
+        self.L_alpha = max(self.rejection_cost, inv_alpha_sum) + self.rejection_cost
+
+    def to(self, device: torch.device) -> "BalancedLinearLoss":
+        self.class_to_group = self.class_to_group.to(device)
+        self.alpha = self.alpha.to(device)
+        self.mu = self.mu.to(device)
+        return self
 
     def __call__(
         self,
         ensemble_probs: torch.Tensor,
         targets: torch.Tensor,
         group_ids: torch.Tensor,
-    ) -> torch.Tensor:
-        """Compute balanced linear loss according to Formula (6)"""
+        return_details: bool = False,
+    ) -> Union[Tuple[torch.Tensor, torch.Tensor], Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]]:
         device = ensemble_probs.device
-        batch_size, num_classes = ensemble_probs.shape
+        class_to_group = self.class_to_group.to(device)
+        alpha_by_group = self.alpha.to(device)
+        mu_by_group = self.mu.to(device)
 
-        # Create alpha and mu tensors for all classes
-        alpha_tensor = torch.zeros(num_classes, device=device)
-        mu_tensor = torch.zeros(num_classes, device=device)
+        alpha_per_class = alpha_by_group[class_to_group]
+        mu_per_class = mu_by_group[class_to_group]
 
-        for class_id in range(num_classes):
-            group_id = self.class_to_group[class_id]
-            alpha_tensor[class_id] = self.alpha[group_id]
-            mu_tensor[class_id] = self.mu[group_id]
-
-        # Classifier h_θ(x) = argmax_y p_Qθ,y(x) / α[group[y]] (Formula 5a)
-        weighted_probs = ensemble_probs / alpha_tensor.unsqueeze(0)
+        weighted_probs = ensemble_probs / alpha_per_class.unsqueeze(0)
         predictions = torch.argmax(weighted_probs, dim=-1)
-
-        # Rejector decision (Formula 5b)
-        # LHS: max_y p_Qθ,y(x) / α[group[y]]
-        lhs = torch.max(weighted_probs, dim=-1)[0]
-
-        # RHS: Σ_j (1/α[group[j]] - μ[group[j]]) * p_Qθ,j(x) - c
-        rhs_coeffs = 1.0 / alpha_tensor - mu_tensor
-        rhs = (
-            torch.sum(rhs_coeffs.unsqueeze(0) * ensemble_probs, dim=-1)
-            - self.rejection_cost
-        )
-
-        # Accept if lhs >= rhs, reject otherwise
+        lhs = torch.max(weighted_probs, dim=-1).values
+        rhs_coeffs = (1.0 / alpha_per_class) - mu_per_class
+        rhs = torch.sum(rhs_coeffs.unsqueeze(0) * ensemble_probs, dim=-1) - self.rejection_cost
         accept_mask = lhs >= rhs
 
-        # Compute loss according to Formula (6):
-        # ℓ_α(θ;(x,y)) = Σ_k (1/α_k) * 1[y∈G_k] * 1[r_θ(x)=0] * 1[h_θ(x)≠y] + c * 1[r_θ(x)=1]
         error_mask = predictions != targets
-
-        # Get alpha values for target groups
-        target_alphas = torch.tensor(
-            [self.alpha[group_ids[i].item()] for i in range(batch_size)], device=device
+        target_alpha = alpha_by_group[group_ids]
+        raw_loss = error_mask.float() * accept_mask.float() / target_alpha + (
+            self.rejection_cost * (~accept_mask).float()
         )
 
-        # Loss computation
-        accept_error_loss = (
-            (1.0 / target_alphas) * accept_mask.float() * error_mask.float()
-        )
-        reject_loss = self.rejection_cost * (~accept_mask).float()
+        raw_mean = raw_loss.mean()
+        normalized_mean = (raw_loss / self.L_alpha).mean()
 
-        raw_loss = accept_error_loss + reject_loss
-
-        # Normalize by L_α to get ℓ̃_α ∈ [0,1] for PAC-Bayes
-        normalized_loss = raw_loss / self.L_alpha
-
-        return normalized_loss.mean()
+        if return_details:
+            return raw_mean, normalized_mean, predictions, accept_mask
+        return raw_mean, normalized_mean
 
 
 def create_gating_features(
     model_probs_list: List[List[torch.Tensor]],
     group_onehots: List[torch.Tensor],
     config: Dict,
+    group_info: Optional[Dict] = None,
 ) -> torch.Tensor:
-    """Create gating features from model probabilities"""
-    feature_extractor = FeatureExtractor(config)
-
-    all_features = []
-    for i, model_probs in enumerate(model_probs_list):
-        group_onehot = group_onehots[i] if i < len(group_onehots) else None
-        features = feature_extractor.extract(model_probs, group_onehot)
-        all_features.append(features)
-
-    return torch.cat(all_features, dim=0)
+    extractor = FeatureExtractor(config, group_info)
+    features: List[torch.Tensor] = []
+    for probs, group_onehot in zip(model_probs_list, group_onehots):
+        features.append(extractor.extract(probs, group_onehot))
+    return torch.cat(features, dim=0)

--- a/pb_gse/models/inference.py
+++ b/pb_gse/models/inference.py
@@ -1,360 +1,124 @@
-"""
-Inference and worst-group extension with Exponentiated Gradient
-"""
+"""Inference utilities for PB-GSE."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Tuple
 
 import torch
-import torch.nn.functional as F
-import numpy as np
-from typing import Dict, List, Tuple, Optional
-import logging
-from .plugin_rule import PluginRule, PluginOptimizer
+
 from .gating import PACBayesGating
-
-
-class ExponentiatedGradient:
-    """Exponentiated Gradient algorithm for worst-group optimization"""
-    
-    def __init__(self, num_groups: int, learning_rate: float = 0.1):
-        self.num_groups = num_groups
-        self.learning_rate = learning_rate
-        self.reset()
-        
-    def reset(self):
-        """Reset to uniform distribution"""
-        self.weights = np.ones(self.num_groups) / self.num_groups
-        
-    def update(self, losses: np.ndarray):
-        """Update weights using exponentiated gradient"""
-        # Exponentiated gradient update
-        self.weights = self.weights * np.exp(self.learning_rate * losses)
-        
-        # Normalize to maintain simplex constraint
-        self.weights = self.weights / np.sum(self.weights)
-        
-    def get_weights(self) -> np.ndarray:
-        """Get current weights"""
-        return self.weights.copy()
-
-
-class WorstGroupOptimizer:
-    """Worst-group extension using mixture of abstainers"""
-    
-    def __init__(self, config: Dict):
-        self.config = config['worst_group']
-        self.num_groups = config['groups']['num_groups']
-        self.max_iterations = self.config['max_iterations']
-        self.learning_rate = self.config['learning_rate']
-        self.inner_epochs = self.config['inner_epochs']
-        
-        # Initialize EG optimizer
-        self.eg_optimizer = ExponentiatedGradient(self.num_groups, self.learning_rate)
-        
-    def optimize(self, gating_model: PACBayesGating, model_probs_list: List[torch.Tensor],
-                targets: torch.Tensor, group_ids: torch.Tensor, group_info: Dict,
-                plugin_optimizer: PluginOptimizer, device: str = 'cuda') -> Tuple[np.ndarray, List[Dict]]:
-        """Run worst-group optimization"""
-        
-        # Store results for each iteration
-        iteration_results = []
-        best_worst_group_error = float('inf')
-        best_weights = None
-        best_plugin_params = None
-        
-        for iteration in range(self.max_iterations):
-            current_weights = self.eg_optimizer.get_weights()
-            logging.info(f"Iteration {iteration + 1}: β = {current_weights}")
-            
-            # Fine-tune gating with current group weights
-            self._fine_tune_gating(gating_model, model_probs_list, targets, 
-                                 group_ids, current_weights, device)
-            
-            # Get ensemble probabilities with updated gating
-            ensemble_probs = self._get_ensemble_probs(
-                gating_model, model_probs_list, group_ids, group_info, device
-            )
-            
-            # Optimize plugin rule parameters
-            alpha, mu = plugin_optimizer.optimize(ensemble_probs, targets, group_ids, group_info)
-            plugin_rule = plugin_optimizer.create_plugin_rule(alpha, mu, group_info)
-            
-            # Evaluate group-wise performance
-            group_losses = self._evaluate_group_performance(
-                plugin_rule, ensemble_probs, targets, group_ids
-            )
-            
-            # Update EG weights
-            self.eg_optimizer.update(group_losses)
-            
-            # Track best performance
-            worst_group_error = np.max(group_losses)
-            if worst_group_error < best_worst_group_error:
-                best_worst_group_error = worst_group_error
-                best_weights = current_weights.copy()
-                best_plugin_params = (alpha.copy(), mu.copy())
-            
-            # Store iteration results
-            iteration_results.append({
-                'iteration': iteration + 1,
-                'group_weights': current_weights.copy(),
-                'group_losses': group_losses.copy(),
-                'worst_group_error': worst_group_error,
-                'alpha': alpha.copy(),
-                'mu': mu.copy()
-            })
-            
-            logging.info(f"Group losses: {group_losses}")
-            logging.info(f"Worst-group error: {worst_group_error}")
-            
-        logging.info(f"Best worst-group error: {best_worst_group_error}")
-        logging.info(f"Best weights: {best_weights}")
-        
-        return best_weights, iteration_results
-    
-    def _fine_tune_gating(self, gating_model: PACBayesGating, model_probs_list: List[torch.Tensor],
-                         targets: torch.Tensor, group_ids: torch.Tensor, 
-                         group_weights: np.ndarray, device: str):
-        """Fine-tune gating model with group-weighted loss"""
-        gating_model.train()
-        
-        # Create optimizer for gating parameters
-        if gating_model.config['method'] == 'gaussian':
-            params = [gating_model.posterior.mu, gating_model.posterior.log_sigma]
-        else:
-            params = gating_model.gating_net.parameters()
-            
-        optimizer = torch.optim.Adam(params, lr=1e-4)
-        
-        # Convert to tensors
-        group_weight_tensor = torch.tensor(group_weights, dtype=torch.float32).to(device)
-        
-        for epoch in range(self.inner_epochs):
-            optimizer.zero_grad()
-            
-            # Forward pass through gating
-            features = gating_model.feature_extractor.extract(model_probs_list)
-            gating_weights = gating_model.forward(features)
-            
-            # Compute ensemble probabilities
-            ensemble_probs = gating_model.compute_ensemble_probs(model_probs_list, gating_weights)
-            
-            # Compute group-weighted loss
-            group_losses = []
-            for group_id in range(self.num_groups):
-                group_mask = (group_ids == group_id)
-                if group_mask.sum() > 0:
-                    group_loss = F.cross_entropy(
-                        torch.log(ensemble_probs[group_mask] + 1e-8), 
-                        targets[group_mask]
-                    )
-                    group_losses.append(group_loss)
-                else:
-                    group_losses.append(torch.tensor(0.0).to(device))
-            
-            # Weighted combination of group losses
-            total_loss = sum(group_weight_tensor[i] * group_losses[i] 
-                           for i in range(self.num_groups))
-            
-            total_loss.backward()
-            optimizer.step()
-    
-    def _get_ensemble_probs(self, gating_model: PACBayesGating, 
-                           model_probs_list: List[torch.Tensor], 
-                           group_ids: torch.Tensor, group_info: Dict, 
-                           device: str) -> torch.Tensor:
-        """Get ensemble probabilities from gating model"""
-        gating_model.eval()
-        
-        with torch.no_grad():
-            # Extract features
-            group_onehot = F.one_hot(group_ids, num_classes=self.num_groups).float()
-            features = gating_model.feature_extractor.extract(model_probs_list, group_onehot)
-            
-            # Get gating weights
-            gating_weights = gating_model.forward(features)
-            
-            # Compute ensemble probabilities
-            ensemble_probs = gating_model.compute_ensemble_probs(model_probs_list, gating_weights)
-            
-        return ensemble_probs
-    
-    def _evaluate_group_performance(self, plugin_rule: PluginRule, 
-                                  ensemble_probs: torch.Tensor, targets: torch.Tensor,
-                                  group_ids: torch.Tensor) -> np.ndarray:
-        """Evaluate performance for each group"""
-        predictions, rejections = plugin_rule.forward(ensemble_probs)
-        accept_mask = (rejections == 0)
-        
-        group_losses = np.zeros(self.num_groups)
-        
-        for group_id in range(self.num_groups):
-            group_mask = (group_ids == group_id)
-            group_accept_mask = group_mask & accept_mask
-            
-            if group_accept_mask.sum() > 0:
-                group_correct = (predictions[group_accept_mask] == targets[group_accept_mask]).float()
-                group_error = 1.0 - group_correct.mean()
-                group_losses[group_id] = group_error.item()
-            else:
-                # No accepted samples in this group
-                group_losses[group_id] = 1.0
-                
-        return group_losses
+from .plugin_rule import PluginOptimizer, PluginRule, compute_group_ids
 
 
 class PBGSEInference:
-    """Main inference class for PB-GSE"""
-    
+    """Run the PB-GSE inference pipeline."""
+
     def __init__(self, config: Dict):
         self.config = config
-        self.plugin_optimizer = PluginOptimizer(config['plugin'])
-        
-        if config['plugin']['worst_group']['enabled']:
-            self.worst_group_optimizer = WorstGroupOptimizer(config)
-        else:
-            self.worst_group_optimizer = None
-    
-    def inference(self, gating_model: PACBayesGating, model_probs_list: List[torch.Tensor],
-                 targets: torch.Tensor, group_info: Dict, device: str = 'cuda') -> Dict:
-        """Run full inference pipeline"""
-        
-        # Compute group IDs
-        class_to_group = group_info['class_to_group']
-        group_ids = torch.tensor([
-            class_to_group[target.item()] for target in targets
-        ]).to(device)
-        
-        results = {}
-        
-        if self.worst_group_optimizer is not None:
-            # Run worst-group optimization
-            logging.info("Running worst-group optimization...")
-            best_weights, iteration_results = self.worst_group_optimizer.optimize(
-                gating_model, model_probs_list, targets, group_ids, 
-                group_info, self.plugin_optimizer, device
-            )
-            
-            results['worst_group'] = {
-                'best_weights': best_weights,
-                'iteration_results': iteration_results
-            }
-            
-            # Use best configuration for final inference
-            # Fine-tune gating one more time with best weights
-            self.worst_group_optimizer._fine_tune_gating(
-                gating_model, model_probs_list, targets, group_ids, best_weights, device
-            )
-            
-        # Get final ensemble probabilities
-        ensemble_probs = self._get_ensemble_probs(
-            gating_model, model_probs_list, group_ids, group_info, device
-        )
-        
-        # Optimize plugin rule parameters
+        self.plugin_optimizer = PluginOptimizer(config["plugin"])
+
+    def _stack_model_probs(self, model_probs_list: List[torch.Tensor]) -> torch.Tensor:
+        if not model_probs_list:
+            raise ValueError("model_probs_list must contain at least one tensor")
+        stacked = torch.stack(model_probs_list, dim=1)
+        if stacked.dim() != 3:
+            raise ValueError("Model probabilities must have shape [N, C]")
+        return stacked
+
+    def _extract_features(
+        self,
+        gating_model: PACBayesGating,
+        stacked_probs: torch.Tensor,
+        group_onehot: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        extractor = gating_model.feature_extractor
+        return extractor.extract(stacked_probs, group_onehot)
+
+    def inference(
+        self,
+        gating_model: PACBayesGating,
+        model_probs_list: List[torch.Tensor],
+        targets: torch.Tensor,
+        group_info: Dict,
+        device: torch.device,
+    ) -> Dict[str, torch.Tensor]:
+        gating_model.eval()
+        stacked_probs = self._stack_model_probs([p.to(device) for p in model_probs_list])
+        targets = targets.to(device)
+
+        group_onehot = None
+        extractor = gating_model.feature_extractor
+        if getattr(extractor, "use_group_onehot", False):
+            num_groups = extractor.num_groups
+            if num_groups <= 0:
+                raise ValueError("Feature extractor expects group one-hot but num_groups is 0")
+            group_onehot = torch.zeros(stacked_probs.size(0), num_groups, device=device)
+
+        with torch.no_grad():
+            features = self._extract_features(gating_model, stacked_probs, group_onehot)
+            gating_weights = gating_model(features, sample=False)
+            ensemble_probs = gating_model.compute_ensemble_probs(stacked_probs, gating_weights)
+
+        group_ids = compute_group_ids(targets, group_info)
         alpha, mu = self.plugin_optimizer.optimize(ensemble_probs, targets, group_ids, group_info)
         plugin_rule = self.plugin_optimizer.create_plugin_rule(alpha, mu, group_info)
-        
-        # Final predictions
         predictions, rejections = plugin_rule.forward(ensemble_probs)
-        
-        results.update({
-            'ensemble_probs': ensemble_probs,
-            'predictions': predictions,
-            'rejections': rejections,
-            'alpha': alpha,
-            'mu': mu,
-            'plugin_rule': plugin_rule
-        })
-        
+
+        results: Dict[str, torch.Tensor] = {
+            "ensemble_probs": ensemble_probs,
+            "predictions": predictions,
+            "rejections": rejections,
+        }
+        results["alpha"] = torch.tensor([alpha[int(k)] for k in sorted(alpha.keys())], device=device)
+        results["mu"] = torch.tensor([mu[int(k)] for k in sorted(mu.keys())], device=device)
+        results["plugin_rule"] = plugin_rule
+
         return results
-    
-    def _get_ensemble_probs(self, gating_model: PACBayesGating, 
-                           model_probs_list: List[torch.Tensor], 
-                           group_ids: torch.Tensor, group_info: Dict, 
-                           device: str) -> torch.Tensor:
-        """Get ensemble probabilities from gating model"""
+
+    def predict(
+        self,
+        gating_model: PACBayesGating,
+        model_probs_list: List[torch.Tensor],
+        plugin_rule: PluginRule,
+        device: torch.device,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         gating_model.eval()
-        
+        stacked_probs = self._stack_model_probs([p.to(device) for p in model_probs_list])
+
+        extractor = gating_model.feature_extractor
+        group_onehot = None
+        if getattr(extractor, "use_group_onehot", False) and extractor.num_groups > 0:
+            group_onehot = torch.zeros(stacked_probs.size(0), extractor.num_groups, device=device)
+
         with torch.no_grad():
-            # Extract features
-            num_groups = self.config['plugin']['groups']['num_groups']
-            group_onehot = F.one_hot(group_ids, num_classes=num_groups).float()
-            features = gating_model.feature_extractor.extract(model_probs_list, group_onehot)
-            
-            # Get gating weights
-            gating_weights = gating_model.forward(features)
-            
-            # Compute ensemble probabilities
-            ensemble_probs = gating_model.compute_ensemble_probs(model_probs_list, gating_weights)
-            
-        return ensemble_probs
-    
-    def predict(self, gating_model: PACBayesGating, model_probs_list: List[torch.Tensor],
-               plugin_rule: PluginRule, group_info: Dict, device: str = 'cuda') -> Tuple[torch.Tensor, torch.Tensor]:
-        """Make predictions on new data"""
-        gating_model.eval()
-        
-        with torch.no_grad():
-            # Dummy group IDs (we don't know true labels)
-            batch_size = model_probs_list[0].size(0)
-            num_groups = self.config['plugin']['groups']['num_groups']
-            
-            # Use uniform group distribution as default
-            group_ids = torch.zeros(batch_size, dtype=torch.long).to(device)
-            group_onehot = F.one_hot(group_ids, num_classes=num_groups).float()
-            
-            # Extract features
-            features = gating_model.feature_extractor.extract(model_probs_list, group_onehot)
-            
-            # Get gating weights
-            gating_weights = gating_model.forward(features)
-            
-            # Compute ensemble probabilities
-            ensemble_probs = gating_model.compute_ensemble_probs(model_probs_list, gating_weights)
-            
-            # Apply plugin rule
+            features = self._extract_features(gating_model, stacked_probs, group_onehot)
+            gating_weights = gating_model(features, sample=False)
+            ensemble_probs = gating_model.compute_ensemble_probs(stacked_probs, gating_weights)
             predictions, rejections = plugin_rule.forward(ensemble_probs)
-            
         return predictions, rejections
 
 
-def save_inference_results(results: Dict, save_path: str):
-    """Save inference results"""
-    # Convert tensors to numpy for saving
-    save_dict = {}
-    
+def save_inference_results(results: Dict, save_path: str) -> None:
+    serialisable = {}
     for key, value in results.items():
         if isinstance(value, torch.Tensor):
-            save_dict[key] = value.cpu().numpy()
-        elif isinstance(value, dict):
-            save_dict[key] = {}
-            for sub_key, sub_value in value.items():
-                if isinstance(sub_value, torch.Tensor):
-                    save_dict[key][sub_key] = sub_value.cpu().numpy()
-                else:
-                    save_dict[key][sub_key] = sub_value
+            serialisable[key] = value.cpu()
+        elif isinstance(value, PluginRule):
+            serialisable[key] = {
+                "alpha": value.alpha.cpu(),
+                "mu": value.mu.cpu(),
+            }
         else:
-            save_dict[key] = value
-    
-    torch.save(save_dict, save_path)
+            serialisable[key] = value
+    torch.save(serialisable, save_path)
 
 
-def load_inference_results(load_path: str, device: str = 'cuda') -> Dict:
-    """Load inference results"""
-    save_dict = torch.load(load_path, map_location=device)
-    
-    # Convert numpy arrays back to tensors
-    results = {}
-    for key, value in save_dict.items():
-        if isinstance(value, np.ndarray):
-            results[key] = torch.from_numpy(value).to(device)
-        elif isinstance(value, dict):
-            results[key] = {}
-            for sub_key, sub_value in value.items():
-                if isinstance(sub_value, np.ndarray):
-                    results[key][sub_key] = torch.from_numpy(sub_value).to(device)
-                else:
-                    results[key][sub_key] = sub_value
+def load_inference_results(load_path: str, device: torch.device) -> Dict:
+    saved = torch.load(load_path, map_location=device)
+    results: Dict = {}
+    for key, value in saved.items():
+        if isinstance(value, torch.Tensor):
+            results[key] = value.to(device)
         else:
             results[key] = value
-            
     return results

--- a/pb_gse/models/metrics.py
+++ b/pb_gse/models/metrics.py
@@ -1,375 +1,256 @@
-"""
-Evaluation metrics for PB-GSE
-"""
+"""Evaluation metrics for PB-GSE."""
 
-import torch
-import numpy as np
-from typing import Dict, List, Tuple, Optional
-from sklearn.metrics import roc_auc_score
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Sequence, Tuple
+
 import matplotlib.pyplot as plt
+import numpy as np
+import torch
 
 
 class SelectiveMetrics:
-    """Metrics for selective prediction/classification with abstention"""
-    
+    """Compute selective prediction metrics with optional group information."""
+
     def __init__(self, num_groups: int = 2):
         self.num_groups = num_groups
-    
-    def compute_all_metrics(self, predictions: torch.Tensor, targets: torch.Tensor,
-                          rejections: torch.Tensor, group_ids: torch.Tensor,
-                          probs: Optional[torch.Tensor] = None) -> Dict[str, float]:
-        """Compute all selective prediction metrics"""
-        
-        results = {}
-        
-        # Basic metrics
-        results.update(self.compute_basic_metrics(predictions, targets, rejections))
-        
-        # Group-wise metrics
-        results.update(self.compute_group_metrics(predictions, targets, rejections, group_ids))
-        
-        # Coverage-based metrics
+
+    def compute_all_metrics(
+        self,
+        predictions: torch.Tensor,
+        targets: torch.Tensor,
+        rejections: torch.Tensor,
+        group_ids: Optional[torch.Tensor] = None,
+        probs: Optional[torch.Tensor] = None,
+    ) -> Dict[str, float]:
+        metrics = self.compute_basic_metrics(predictions, targets, rejections)
+        if group_ids is not None:
+            metrics.update(self.compute_group_metrics(predictions, targets, rejections, group_ids))
         if probs is not None:
-            results.update(self.compute_coverage_metrics(predictions, targets, rejections, probs))
-            results.update(self.compute_calibration_metrics(predictions, targets, rejections, 
-                                                          group_ids, probs))
-        
-        return results
-    
-    def compute_basic_metrics(self, predictions: torch.Tensor, targets: torch.Tensor,
-                            rejections: torch.Tensor) -> Dict[str, float]:
-        """Compute basic selective prediction metrics"""
-        
-        accept_mask = (rejections == 0)
-        
-        # Coverage (acceptance rate)
+            metrics.update(self.compute_coverage_metrics(predictions, targets, probs))
+            if group_ids is not None:
+                metrics.update(
+                    self.compute_calibration_metrics(predictions, targets, rejections, group_ids, probs)
+                )
+        return metrics
+
+    def compute_basic_metrics(
+        self,
+        predictions: torch.Tensor,
+        targets: torch.Tensor,
+        rejections: torch.Tensor,
+    ) -> Dict[str, float]:
+        accept_mask = rejections == 0
         coverage = accept_mask.float().mean().item()
-        
-        # Selective accuracy/error
         if accept_mask.sum() > 0:
-            accepted_correct = (predictions[accept_mask] == targets[accept_mask]).float()
-            selective_accuracy = accepted_correct.mean().item()
-            selective_error = 1.0 - selective_accuracy
+            acc = (predictions[accept_mask] == targets[accept_mask]).float().mean().item()
         else:
-            selective_accuracy = 0.0
-            selective_error = 1.0
-        
-        # Overall accuracy (treating rejections as incorrect)
-        overall_correct = accept_mask.float() * (predictions == targets).float()
-        overall_accuracy = overall_correct.mean().item()
-        
+            acc = 0.0
+        overall_acc = (accept_mask.float() * (predictions == targets).float()).mean().item()
         return {
-            'coverage': coverage,
-            'rejection_rate': 1.0 - coverage,
-            'selective_accuracy': selective_accuracy,
-            'selective_error': selective_error,
-            'overall_accuracy': overall_accuracy,
-            'overall_error': 1.0 - overall_accuracy
+            "coverage": coverage,
+            "rejection_rate": 1.0 - coverage,
+            "selective_accuracy": acc,
+            "selective_error": 1.0 - acc,
+            "overall_accuracy": overall_acc,
+            "overall_error": 1.0 - overall_acc,
         }
-    
-    def compute_group_metrics(self, predictions: torch.Tensor, targets: torch.Tensor,
-                            rejections: torch.Tensor, group_ids: torch.Tensor) -> Dict[str, float]:
-        """Compute group-wise metrics"""
-        
-        accept_mask = (rejections == 0)
-        
-        # Group-wise coverage and errors
-        group_coverage = []
-        group_errors = []
-        group_acceptance_rates = []
-        
-        for group_id in range(self.num_groups):
-            group_mask = (group_ids == group_id)
-            
+
+    def compute_group_metrics(
+        self,
+        predictions: torch.Tensor,
+        targets: torch.Tensor,
+        rejections: torch.Tensor,
+        group_ids: torch.Tensor,
+    ) -> Dict[str, float]:
+        accept_mask = rejections == 0
+        group_coverage: List[float] = []
+        group_errors: List[float] = []
+        group_acceptance: List[float] = []
+
+        for group in range(self.num_groups):
+            group_mask = group_ids == group
             if group_mask.sum() == 0:
                 group_coverage.append(0.0)
                 group_errors.append(1.0)
-                group_acceptance_rates.append(0.0)
+                group_acceptance.append(0.0)
                 continue
-            
-            # Group coverage (acceptance rate within group)
-            group_accept_mask = group_mask & accept_mask
-            group_cov = group_accept_mask.float().sum() / group_mask.float().sum()
-            group_coverage.append(group_cov.item())
-            
-            # Group error (error rate among accepted samples in group)
-            if group_accept_mask.sum() > 0:
-                group_correct = (predictions[group_accept_mask] == targets[group_accept_mask]).float()
-                group_error = 1.0 - group_correct.mean()
-                group_errors.append(group_error.item())
+
+            group_accept = group_mask & accept_mask
+            coverage = group_accept.float().sum().item() / group_mask.float().sum().item()
+            group_coverage.append(coverage)
+
+            if group_accept.sum() > 0:
+                err = 1.0 - (predictions[group_accept] == targets[group_accept]).float().mean().item()
             else:
-                group_errors.append(1.0)  # No accepted samples
-            
-            # Acceptance rate (what fraction of accepted samples are from this group)
+                err = 1.0
+            group_errors.append(err)
+
             if accept_mask.sum() > 0:
-                acceptance_rate = group_accept_mask.float().sum() / accept_mask.float().sum()
-                group_acceptance_rates.append(acceptance_rate.item())
+                group_acceptance.append(group_accept.float().sum().item() / accept_mask.float().sum().item())
             else:
-                group_acceptance_rates.append(0.0)
-        
-        # Balanced selective error (BSE)
-        balanced_selective_error = np.mean(group_errors)
-        
-        # Worst-group selective error (WGSE)
-        worst_group_selective_error = np.max(group_errors)
-        
-        # Coverage fairness (standard deviation of group coverage)
-        coverage_fairness = np.std(group_coverage)
-        
-        return {
-            'balanced_selective_error': balanced_selective_error,
-            'worst_group_selective_error': worst_group_selective_error,
-            'group_coverage': group_coverage,
-            'group_errors': group_errors,
-            'group_acceptance_rates': group_acceptance_rates,
-            'coverage_fairness': coverage_fairness
+                group_acceptance.append(0.0)
+
+        metrics = {
+            "balanced_selective_error": float(np.mean(group_errors)),
+            "worst_group_selective_error": float(np.max(group_errors)),
+            "group_coverage": group_coverage,
+            "group_errors": group_errors,
+            "group_acceptance_rates": group_acceptance,
+            "coverage_fairness": float(np.std(group_coverage)),
         }
-    
-    def compute_coverage_metrics(self, predictions: torch.Tensor, targets: torch.Tensor,
-                               rejections: torch.Tensor, probs: torch.Tensor) -> Dict[str, float]:
-        """Compute coverage-based metrics like AURC"""
-        
-        # Get confidence scores
-        confidences = torch.max(probs, dim=1)[0]
-        
-        # Sort by confidence (descending)
-        sorted_indices = torch.argsort(confidences, descending=True)
-        sorted_predictions = predictions[sorted_indices]
-        sorted_targets = targets[sorted_indices]
-        sorted_confidences = confidences[sorted_indices]
-        
-        # Compute risk-coverage curve
-        coverages = []
-        risks = []
-        
-        n_samples = len(sorted_predictions)
-        
-        for i in range(1, n_samples + 1):
-            # Coverage: fraction of samples included
-            coverage = i / n_samples
-            
-            # Risk: error rate among included samples
-            included_correct = (sorted_predictions[:i] == sorted_targets[:i]).float()
-            risk = 1.0 - included_correct.mean()
-            
+        return metrics
+
+    def compute_coverage_metrics(
+        self,
+        predictions: torch.Tensor,
+        targets: torch.Tensor,
+        probs: torch.Tensor,
+    ) -> Dict[str, float]:
+        confidences = torch.max(probs, dim=1).values
+        sorted_confidences, indices = torch.sort(confidences, descending=True)
+        sorted_predictions = predictions[indices]
+        sorted_targets = targets[indices]
+
+        coverages: List[float] = []
+        risks: List[float] = []
+        n = len(sorted_predictions)
+        for i in range(1, n + 1):
+            coverage = i / n
+            risk = 1.0 - (sorted_predictions[:i] == sorted_targets[:i]).float().mean().item()
             coverages.append(coverage)
-            risks.append(risk.item())
-        
-        # Compute AURC (Area Under Risk-Coverage curve)
-        aurc = np.trapz(risks, coverages)
-        
-        return {
-            'aurc': aurc,
-            'risk_coverage_curve': (coverages, risks)
-        }
-    
-    def compute_calibration_metrics(self, predictions: torch.Tensor, targets: torch.Tensor,
-                                  rejections: torch.Tensor, group_ids: torch.Tensor,
-                                  probs: torch.Tensor, n_bins: int = 15) -> Dict[str, float]:
-        """Compute calibration metrics (ECE) per group"""
-        
-        accept_mask = (rejections == 0)
-        
+            risks.append(risk)
+
+        aurc = float(np.trapz(risks, coverages))
+        return {"aurc": aurc, "risk_coverage_curve": (coverages, risks)}
+
+    def compute_calibration_metrics(
+        self,
+        predictions: torch.Tensor,
+        targets: torch.Tensor,
+        rejections: torch.Tensor,
+        group_ids: torch.Tensor,
+        probs: torch.Tensor,
+        n_bins: int = 15,
+    ) -> Dict[str, float]:
+        accept_mask = rejections == 0
         if accept_mask.sum() == 0:
-            return {
-                'overall_ece': 1.0,
-                'group_ece': [1.0] * self.num_groups
-            }
-        
-        # Overall ECE
+            return {"overall_ece": 1.0, "group_ece": [1.0] * self.num_groups}
+
         accepted_probs = probs[accept_mask]
-        accepted_predictions = predictions[accept_mask]
         accepted_targets = targets[accept_mask]
-        
-        overall_ece = self._expected_calibration_error(
-            accepted_probs, accepted_targets, n_bins
-        )
-        
-        # Group-wise ECE
-        group_ece = []
-        for group_id in range(self.num_groups):
-            group_mask = (group_ids == group_id) & accept_mask
-            
-            if group_mask.sum() > 0:
-                group_probs = probs[group_mask]
-                group_targets = targets[group_mask]
-                ece = self._expected_calibration_error(group_probs, group_targets, n_bins)
-                group_ece.append(ece)
-            else:
+        overall_ece = self._expected_calibration_error(accepted_probs, accepted_targets, n_bins)
+
+        group_ece: List[float] = []
+        for group in range(self.num_groups):
+            mask = (group_ids == group) & accept_mask
+            if mask.sum() == 0:
                 group_ece.append(0.0)
-        
-        return {
-            'overall_ece': overall_ece,
-            'group_ece': group_ece
-        }
-    
-    def _expected_calibration_error(self, probs: torch.Tensor, targets: torch.Tensor,
-                                  n_bins: int = 15) -> float:
-        """Compute Expected Calibration Error (ECE)"""
-        
-        # Get confidence scores and predictions
+                continue
+            group_probs = probs[mask]
+            group_targets = targets[mask]
+            group_ece.append(self._expected_calibration_error(group_probs, group_targets, n_bins))
+
+        return {"overall_ece": overall_ece, "group_ece": group_ece}
+
+    @staticmethod
+    def _expected_calibration_error(probs: torch.Tensor, targets: torch.Tensor, n_bins: int) -> float:
         confidences, predictions = torch.max(probs, dim=1)
         accuracies = (predictions == targets).float()
-        
-        # Create bins
-        bin_boundaries = torch.linspace(0, 1, n_bins + 1)
-        bin_lowers = bin_boundaries[:-1]
-        bin_uppers = bin_boundaries[1:]
-        
-        ece = 0.0
-        for bin_lower, bin_upper in zip(bin_lowers, bin_uppers):
-            in_bin = (confidences > bin_lower) & (confidences <= bin_upper)
-            prop_in_bin = in_bin.float().mean()
-            
-            if prop_in_bin > 0:
-                accuracy_in_bin = accuracies[in_bin].mean()
-                avg_confidence_in_bin = confidences[in_bin].mean()
-                ece += torch.abs(avg_confidence_in_bin - accuracy_in_bin) * prop_in_bin
-        
-        return ece.item()
+        bin_boundaries = torch.linspace(0, 1, n_bins + 1, device=probs.device)
+        ece = torch.tensor(0.0, device=probs.device)
+        for lower, upper in zip(bin_boundaries[:-1], bin_boundaries[1:]):
+            in_bin = (confidences > lower) & (confidences <= upper)
+            proportion = in_bin.float().mean()
+            if proportion > 0:
+                accuracy = accuracies[in_bin].mean()
+                avg_conf = confidences[in_bin].mean()
+                ece += torch.abs(avg_conf - accuracy) * proportion
+        return float(ece.item())
 
 
-def compute_metrics_at_coverage(predictions: torch.Tensor, targets: torch.Tensor,
-                              rejections: torch.Tensor, group_ids: torch.Tensor,
-                              probs: torch.Tensor, target_coverage: float,
-                              num_groups: int = 2) -> Dict[str, float]:
-    """Compute metrics at a specific coverage level"""
-    
-    # Get confidence scores
-    confidences = torch.max(probs, dim=1)[0]
-    
-    # Find threshold for target coverage
-    sorted_confidences = torch.sort(confidences, descending=True)[0]
-    threshold_idx = int(target_coverage * len(sorted_confidences))
-    threshold = sorted_confidences[threshold_idx]
-    
-    # Create new rejections based on threshold
-    new_rejections = (confidences < threshold).long()
-    
-    # Compute metrics with new rejections
-    metrics = SelectiveMetrics(num_groups).compute_all_metrics(
-        predictions, targets, new_rejections, group_ids, probs
-    )
-    
-    return metrics
+def compute_metrics_at_coverage(
+    predictions: torch.Tensor,
+    targets: torch.Tensor,
+    probs: torch.Tensor,
+    target_coverage: float,
+    group_ids: Optional[torch.Tensor] = None,
+    num_groups: int = 2,
+) -> Dict[str, float]:
+    confidences = torch.max(probs, dim=1).values
+    sorted_confidences, _ = torch.sort(confidences, descending=True)
+    threshold_index = min(int(target_coverage * len(sorted_confidences)), len(sorted_confidences) - 1)
+    threshold = sorted_confidences[threshold_index]
+    rejections = (confidences < threshold).long()
+
+    metrics = SelectiveMetrics(num_groups)
+    return metrics.compute_all_metrics(predictions, targets, rejections, group_ids, probs)
 
 
 class MetricsLogger:
-    """Logger for tracking metrics across experiments"""
-    
+    """Track metrics across training/evaluation epochs."""
+
     def __init__(self):
-        self.metrics_history = []
-        self.current_metrics = {}
-    
-    def log_metrics(self, metrics: Dict[str, float], epoch: Optional[int] = None,
-                   split: str = 'train'):
-        """Log metrics for a specific epoch and split"""
-        
-        log_entry = {
-            'epoch': epoch,
-            'split': split,
-            'metrics': metrics.copy()
-        }
-        
-        self.metrics_history.append(log_entry)
-        
-        if split not in self.current_metrics:
-            self.current_metrics[split] = {}
-        self.current_metrics[split].update(metrics)
-    
-    def get_best_metrics(self, metric_name: str, split: str = 'val',
-                        maximize: bool = False) -> Tuple[Dict, int]:
-        """Get best metrics based on a specific metric"""
-        
-        relevant_entries = [entry for entry in self.metrics_history 
-                          if entry['split'] == split and metric_name in entry['metrics']]
-        
-        if not relevant_entries:
+        self.metrics_history: List[Dict] = []
+
+    def log_metrics(self, metrics: Dict[str, float], epoch: Optional[int] = None, split: str = "train"):
+        entry = {"epoch": epoch, "split": split, "metrics": metrics.copy()}
+        self.metrics_history.append(entry)
+
+    def get_best_metrics(self, metric_name: str, split: str = "val", maximize: bool = False):
+        relevant = [m for m in self.metrics_history if m["split"] == split and metric_name in m["metrics"]]
+        if not relevant:
             return {}, -1
-        
-        if maximize:
-            best_entry = max(relevant_entries, key=lambda x: x['metrics'][metric_name])
-        else:
-            best_entry = min(relevant_entries, key=lambda x: x['metrics'][metric_name])
-        
-        return best_entry['metrics'], best_entry['epoch']
-    
-    def save_metrics(self, save_path: str):
-        """Save metrics history"""
-        torch.save({
-            'metrics_history': self.metrics_history,
-            'current_metrics': self.current_metrics
-        }, save_path)
-    
-    def load_metrics(self, load_path: str):
-        """Load metrics history"""
-        data = torch.load(load_path)
-        self.metrics_history = data['metrics_history']
-        self.current_metrics = data['current_metrics']
+        best = max(relevant, key=lambda m: m["metrics"][metric_name]) if maximize else min(
+            relevant, key=lambda m: m["metrics"][metric_name]
+        )
+        return best["metrics"], best["epoch"]
+
+    def save_metrics(self, path: str) -> None:
+        torch.save(self.metrics_history, path)
+
+    def load_metrics(self, path: str) -> None:
+        self.metrics_history = torch.load(path)
 
 
-def plot_risk_coverage_curves(risk_coverage_data: List[Tuple[List[float], List[float]]],
-                             labels: List[str], save_path: Optional[str] = None):
-    """Plot risk-coverage curves for multiple methods"""
-    
+def plot_risk_coverage_curves(
+    curves: Sequence[Tuple[Sequence[float], Sequence[float]]],
+    labels: Sequence[str],
+    save_path: Optional[str] = None,
+) -> None:
     plt.figure(figsize=(10, 6))
-    
-    for (coverages, risks), label in zip(risk_coverage_data, labels):
+    for (coverages, risks), label in zip(curves, labels):
         plt.plot(coverages, risks, label=label, linewidth=2)
-    
-    plt.xlabel('Coverage')
-    plt.ylabel('Risk')
-    plt.title('Risk-Coverage Curves')
-    plt.legend()
+    plt.xlabel("Coverage")
+    plt.ylabel("Risk")
+    plt.title("Risk-Coverage Curves")
     plt.grid(True, alpha=0.3)
     plt.xlim(0, 1)
     plt.ylim(0, 1)
-    
+    plt.legend()
     if save_path:
-        plt.savefig(save_path, dpi=300, bbox_inches='tight')
-    
-    plt.show()
+        plt.savefig(save_path, dpi=300, bbox_inches="tight")
+    plt.close()
 
 
-def create_metrics_table(results_dict: Dict[str, Dict[str, float]], 
-                        coverage_levels: List[float] = [0.7, 0.8, 0.9]) -> str:
-    """Create a formatted table of metrics for different methods"""
-    
-    # Define key metrics to include
-    key_metrics = [
-        'balanced_selective_error',
-        'worst_group_selective_error', 
-        'aurc',
-        'overall_ece'
-    ]
-    
-    # Create header
+def create_metrics_table(results: Dict[str, Dict[str, float]], coverage_levels: Sequence[float]) -> str:
     header = "Method".ljust(20)
-    for coverage in coverage_levels:
-        header += f"BSE@{coverage}".ljust(12) + f"WGSE@{coverage}".ljust(12)
+    for level in coverage_levels:
+        header += f"BSE@{level}".ljust(14) + f"WGSE@{level}".ljust(14)
     header += "AURC".ljust(12) + "ECE".ljust(12)
-    
-    table = header + "\n" + "-" * len(header) + "\n"
-    
-    # Add rows for each method
-    for method_name, method_results in results_dict.items():
-        row = method_name.ljust(20)
-        
-        # Add coverage-specific metrics
-        for coverage in coverage_levels:
-            if f'metrics_at_{coverage}' in method_results:
-                metrics = method_results[f'metrics_at_{coverage}']
-                bse = f"{metrics.get('balanced_selective_error', 0.0):.3f}"
-                wgse = f"{metrics.get('worst_group_selective_error', 0.0):.3f}"
-                row += bse.ljust(12) + wgse.ljust(12)
+
+    lines = [header, "-" * len(header)]
+    for method, metrics in results.items():
+        row = method.ljust(20)
+        for level in coverage_levels:
+            key = f"metrics_at_{level}"
+            if key in metrics:
+                m = metrics[key]
+                row += f"{m.get('balanced_selective_error', 0.0):.3f}".ljust(14)
+                row += f"{m.get('worst_group_selective_error', 0.0):.3f}".ljust(14)
             else:
-                row += "N/A".ljust(12) + "N/A".ljust(12)
-        
-        # Add overall metrics
-        aurc = f"{method_results.get('aurc', 0.0):.3f}"
-        ece = f"{method_results.get('overall_ece', 0.0):.3f}"
-        row += aurc.ljust(12) + ece.ljust(12)
-        
-        table += row + "\n"
-    
-    return table
+                row += "N/A".ljust(14) + "N/A".ljust(14)
+        row += f"{metrics.get('aurc', 0.0):.3f}".ljust(12)
+        row += f"{metrics.get('overall_ece', 0.0):.3f}".ljust(12)
+        lines.append(row)
+    return "\n".join(lines)

--- a/pb_gse/models/plugin_rule.py
+++ b/pb_gse/models/plugin_rule.py
@@ -1,16 +1,38 @@
-"""
-Plug-in rule (Theorem 1) and fixed-point optimization for α, μ
-"""
+"""Plug-in rule (Theorem 1) utilities for PB-GSE."""
 
-import torch
-import torch.nn.functional as F
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Sequence, Tuple
+
 import numpy as np
-from typing import Dict, List, Tuple, Optional, Union
-import logging
+import torch
+
+
+def _to_int_dict(mapping: Dict) -> Dict[int, int]:
+    return {int(key): int(value) for key, value in mapping.items()}
+
+
+def _sorted_class_to_group(class_to_group: Dict[int, int]) -> torch.Tensor:
+    processed = _to_int_dict(class_to_group)
+    items = sorted(processed.items(), key=lambda kv: kv[0])
+    if not items:
+        raise ValueError("class_to_group mapping must not be empty")
+    num_classes = items[-1][0] + 1
+    mapping = torch.full((num_classes,), -1, dtype=torch.long)
+    for cls, group in items:
+        mapping[cls] = group
+    return mapping
+
+
+def _group_tensor(values: Dict[int, float]) -> torch.Tensor:
+    processed = {int(k): float(v) for k, v in values.items()}
+    groups = sorted(processed.keys())
+    tensor = torch.tensor([processed[g] for g in groups], dtype=torch.float32)
+    return tensor
 
 
 class PluginRule:
-    """Plug-in optimal rule from Theorem 1"""
+    """Plug-in optimal classifier and rejector as per Theorem 1."""
 
     def __init__(
         self,
@@ -19,74 +41,57 @@ class PluginRule:
         rejection_cost: float,
         group_info: Dict,
     ):
-        self.alpha = alpha
-        self.mu = mu
-        self.rejection_cost = rejection_cost
-        self.group_info = group_info
-        self.class_to_group = group_info["class_to_group"]
+        self.rejection_cost = float(rejection_cost)
+        self.class_to_group = _sorted_class_to_group(group_info["class_to_group"])
+        self.alpha = _group_tensor(alpha)
+        self.mu = _group_tensor(mu)
+        if torch.any(self.alpha <= 0):
+            raise ValueError("alpha values must be positive")
+
+    def _prepare_tensors(self, probs: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        device = probs.device
+        alpha = self.alpha.to(device)
+        mu = self.mu.to(device)
+        class_to_group = self.class_to_group.to(device)
+        return alpha, mu, class_to_group
 
     def classify(self, probs: torch.Tensor) -> torch.Tensor:
-        """Classifier h_θ(x) = argmax_y p_Q_θ,y(x) / α[y]"""
-        num_classes = probs.size(-1)
-
-        # Create alpha tensor for all classes
-        alpha_tensor = torch.zeros(num_classes).to(probs.device)
-        for class_id in range(num_classes):
-            group_id = self.class_to_group[class_id]
-            alpha_tensor[class_id] = self.alpha[group_id]
-
-        # Compute weighted probabilities
-        weighted_probs = probs / alpha_tensor
-
-        return torch.argmax(weighted_probs, dim=-1)
+        alpha, _, class_to_group = self._prepare_tensors(probs)
+        alpha_per_class = alpha[class_to_group]
+        weighted = probs / alpha_per_class.unsqueeze(0)
+        return torch.argmax(weighted, dim=-1)
 
     def reject(self, probs: torch.Tensor) -> torch.Tensor:
-        """Rejector r_θ(x) based on threshold comparison"""
-        batch_size = probs.size(0)
-        num_classes = probs.size(-1)
+        alpha, mu, class_to_group = self._prepare_tensors(probs)
+        alpha_per_class = alpha[class_to_group]
+        mu_per_class = mu[class_to_group]
 
-        # Create alpha and mu tensors
-        alpha_tensor = torch.zeros(num_classes).to(probs.device)
-        mu_tensor = torch.zeros(num_classes).to(probs.device)
-
-        for class_id in range(num_classes):
-            group_id = self.class_to_group[class_id]
-            alpha_tensor[class_id] = self.alpha[group_id]
-            mu_tensor[class_id] = self.mu[group_id]
-
-        # Left-hand side: max_y p_Q_θ,y(x) / α[y]
-        weighted_probs = probs / alpha_tensor
-        lhs = torch.max(weighted_probs, dim=-1)[0]
-
-        # Right-hand side: Σ_j (1/α[j] - μ[j]) p_Q_θ,j(x) - c
-        rhs_coeffs = 1.0 / alpha_tensor - mu_tensor
-        rhs = torch.sum(rhs_coeffs * probs, dim=-1) - self.rejection_cost
-
-        # Reject if lhs < rhs
+        weighted = probs / alpha_per_class.unsqueeze(0)
+        lhs = torch.max(weighted, dim=-1).values
+        rhs_coeffs = (1.0 / alpha_per_class) - mu_per_class
+        rhs = torch.sum(rhs_coeffs.unsqueeze(0) * probs, dim=-1) - self.rejection_cost
         return (lhs < rhs).long()
 
     def forward(self, probs: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-        """Full forward pass: classify and reject"""
         predictions = self.classify(probs)
         rejections = self.reject(probs)
-
         return predictions, rejections
 
 
 class FixedPointSolver:
-    """Fixed-point iteration for α parameters with damping and clipping"""
+    """Fixed-point iteration for the α parameters."""
 
     def __init__(
         self,
         max_iterations: int = 20,
         tolerance: float = 1e-6,
         damping_factor: float = 0.3,
-        eps: float = 0.01,
+        eps: float = 1e-3,
     ):
         self.max_iterations = max_iterations
         self.tolerance = tolerance
-        self.damping_factor = damping_factor  # ρ in α^{t+1} ← (1-ρ)α^t + ρ * new_α
-        self.eps = eps  # for clipping: α_k ∈ [ε, K-ε]
+        self.damping_factor = damping_factor
+        self.eps = eps
 
     def solve_alpha(
         self,
@@ -96,70 +101,71 @@ class FixedPointSolver:
         mu: Dict[int, float],
         rejection_cost: float,
         group_info: Dict,
-        num_groups: int = 2,
+        num_groups: int,
     ) -> Dict[int, float]:
-        """Solve for α using fixed-point iteration"""
+        total = float(probs.size(0))
+        if total == 0:
+            raise ValueError("No samples provided for fixed-point iteration")
 
-        # Initialize α
         alpha = {group_id: 1.0 for group_id in range(num_groups)}
-
         for iteration in range(self.max_iterations):
-            alpha_old = alpha.copy()
-
-            # Create plugin rule with current α
+            old_alpha = alpha.copy()
             plugin_rule = PluginRule(alpha, mu, rejection_cost, group_info)
-
-            # Compute decisions
-            predictions, rejections = plugin_rule.forward(probs)
+            _, rejections = plugin_rule.forward(probs)
             accept_mask = rejections == 0
 
-            # Update α for each group with damping and clipping
             for group_id in range(num_groups):
                 group_mask = group_ids == group_id
-                group_accept_mask = group_mask & accept_mask
+                accept_count = (group_mask & accept_mask).sum().item()
+                joint_prob = accept_count / total
+                new_alpha = max(self.eps, min(num_groups - self.eps, num_groups * joint_prob))
+                alpha[group_id] = (
+                    (1 - self.damping_factor) * old_alpha[group_id]
+                    + self.damping_factor * new_alpha
+                )
 
-                if group_mask.sum() > 0:
-                    accept_rate = (
-                        group_accept_mask.sum().float() / group_mask.sum().float()
-                    )
-                    new_alpha = num_groups * accept_rate.item()
-
-                    # Apply damping: α^{t+1} ← (1-ρ)α^t + ρ * new_α
-                    alpha[group_id] = (1 - self.damping_factor) * alpha_old[
-                        group_id
-                    ] + self.damping_factor * new_alpha
-
-                    # Apply clipping: α_k ∈ [ε, K-ε]
-                    alpha[group_id] = max(
-                        self.eps, min(num_groups - self.eps, alpha[group_id])
-                    )
-                else:
-                    alpha[group_id] = 1.0
-
-            # Check convergence
-            converged = True
-            for group_id in range(num_groups):
-                if abs(alpha[group_id] - alpha_old[group_id]) > self.tolerance:
-                    converged = False
-                    break
-
-            if converged:
-                logging.info(f"Fixed-point converged after {iteration + 1} iterations")
+            max_change = max(abs(alpha[g] - old_alpha[g]) for g in range(num_groups))
+            if max_change < self.tolerance:
                 break
-        else:
-            logging.warning(
-                f"Fixed-point did not converge after {self.max_iterations} iterations"
-            )
 
         return alpha
 
 
 class GridSearchOptimizer:
-    """Grid search for optimal λ (and thus μ) parameters"""
+    """Grid search over λ to determine μ and α."""
 
-    def __init__(self, lambda_grid: List[float], num_groups: int = 2):
-        self.lambda_grid = lambda_grid
+    def __init__(self, lambda_grid: Sequence[float], num_groups: int = 2):
+        self.lambda_grid = list(lambda_grid)
         self.num_groups = num_groups
+
+    def _lambda_to_mu(self, lambda_value: float) -> Dict[int, float]:
+        if self.num_groups == 2:
+            return {0: lambda_value, 1: -lambda_value}
+        mu = {}
+        for group in range(self.num_groups):
+            sign = 1.0 if group % 2 == 0 else -1.0
+            mu[group] = lambda_value * sign
+        return mu
+
+    def _evaluate(self, predictions, targets, rejections, group_ids, metric: str) -> float:
+        accept_mask = rejections == 0
+        if accept_mask.sum() == 0:
+            return 1.0
+
+        group_errors: List[float] = []
+        for group_id in torch.unique(group_ids):
+            mask = (group_ids == group_id) & accept_mask
+            if mask.sum() == 0:
+                group_errors.append(1.0)
+                continue
+            error = 1.0 - (predictions[mask] == targets[mask]).float().mean().item()
+            group_errors.append(error)
+
+        if metric == "balanced_selective_error":
+            return float(np.mean(group_errors))
+        if metric == "worst_group_error":
+            return float(np.max(group_errors))
+        raise ValueError(f"Unsupported metric: {metric}")
 
     def optimize(
         self,
@@ -168,148 +174,49 @@ class GridSearchOptimizer:
         group_ids: torch.Tensor,
         rejection_cost: float,
         group_info: Dict,
+        fixed_point_solver: FixedPointSolver,
         metric: str = "balanced_selective_error",
     ) -> Tuple[Dict[int, float], Dict[int, float], float]:
-        """Optimize μ parameters using grid search"""
-
         best_score = float("inf")
-        best_alpha = None
-        best_mu = None
-        best_lambda = None
+        best_alpha: Optional[Dict[int, float]] = None
+        best_mu: Optional[Dict[int, float]] = None
+        best_lambda: float = 0.0
 
-        fixed_point_solver = FixedPointSolver()
-
-        for lambda_val in self.lambda_grid:
-            # Set μ = [λ, -λ] for 2 groups
-            if self.num_groups == 2:
-                mu = {0: lambda_val, 1: -lambda_val}  # head: λ, tail: -λ
-            else:
-                # For more groups, distribute λ values
-                mu = {}
-                for group_id in range(self.num_groups):
-                    # Simple strategy: alternate signs
-                    mu[group_id] = lambda_val * (1 if group_id % 2 == 0 else -1)
-
-            # Solve for α with current μ
+        for lambda_value in self.lambda_grid:
+            mu = self._lambda_to_mu(lambda_value)
             alpha = fixed_point_solver.solve_alpha(
-                probs,
-                targets,
-                group_ids,
-                mu,
-                rejection_cost,
-                group_info,
-                self.num_groups,
+                probs, targets, group_ids, mu, rejection_cost, group_info, self.num_groups
             )
-
-            # Evaluate performance
-            score = self._evaluate_performance(
-                probs, targets, group_ids, alpha, mu, rejection_cost, group_info, metric
-            )
-
+            plugin_rule = PluginRule(alpha, mu, rejection_cost, group_info)
+            predictions, rejections = plugin_rule.forward(probs)
+            score = self._evaluate(predictions, targets, rejections, group_ids, metric)
             if score < best_score:
                 best_score = score
-                best_alpha = alpha.copy()
-                best_mu = mu.copy()
-                best_lambda = lambda_val
+                best_alpha = alpha
+                best_mu = mu
+                best_lambda = lambda_value
 
-        logging.info(f"Best lambda: {best_lambda}, Best score: {best_score}")
+        if best_alpha is None or best_mu is None:
+            raise RuntimeError("Grid search failed to produce parameters")
+
         return best_alpha, best_mu, best_lambda
-
-    def _evaluate_performance(
-        self,
-        probs: torch.Tensor,
-        targets: torch.Tensor,
-        group_ids: torch.Tensor,
-        alpha: Dict[int, float],
-        mu: Dict[int, float],
-        rejection_cost: float,
-        group_info: Dict,
-        metric: str,
-    ) -> float:
-        """Evaluate performance metric"""
-
-        plugin_rule = PluginRule(alpha, mu, rejection_cost, group_info)
-        predictions, rejections = plugin_rule.forward(probs)
-
-        if metric == "balanced_selective_error":
-            return self._compute_balanced_selective_error(
-                predictions, targets, rejections, group_ids
-            )
-        elif metric == "worst_group_error":
-            return self._compute_worst_group_error(
-                predictions, targets, rejections, group_ids
-            )
-        else:
-            raise ValueError(f"Unsupported metric: {metric}")
-
-    def _compute_balanced_selective_error(
-        self,
-        predictions: torch.Tensor,
-        targets: torch.Tensor,
-        rejections: torch.Tensor,
-        group_ids: torch.Tensor,
-    ) -> float:
-        """Compute balanced selective error"""
-        accept_mask = rejections == 0
-
-        if accept_mask.sum() == 0:
-            return 1.0  # All rejected
-
-        group_errors = []
-        unique_groups = torch.unique(group_ids)
-
-        for group_id in unique_groups:
-            group_mask = (group_ids == group_id) & accept_mask
-
-            if group_mask.sum() > 0:
-                group_correct = (predictions[group_mask] == targets[group_mask]).float()
-                group_error = 1.0 - group_correct.mean()
-                group_errors.append(group_error.item())
-            else:
-                group_errors.append(0.0)  # No samples in this group
-
-        return np.mean(group_errors)
-
-    def _compute_worst_group_error(
-        self,
-        predictions: torch.Tensor,
-        targets: torch.Tensor,
-        rejections: torch.Tensor,
-        group_ids: torch.Tensor,
-    ) -> float:
-        """Compute worst-group error"""
-        accept_mask = rejections == 0
-
-        if accept_mask.sum() == 0:
-            return 1.0  # All rejected
-
-        group_errors = []
-        unique_groups = torch.unique(group_ids)
-
-        for group_id in unique_groups:
-            group_mask = (group_ids == group_id) & accept_mask
-
-            if group_mask.sum() > 0:
-                group_correct = (predictions[group_mask] == targets[group_mask]).float()
-                group_error = 1.0 - group_correct.mean()
-                group_errors.append(group_error.item())
-
-        return max(group_errors) if group_errors else 1.0
 
 
 class PluginOptimizer:
-    """Main optimizer for plugin rule parameters"""
+    """Utility wrapper for optimising plug-in rule parameters."""
 
     def __init__(self, config: Dict):
         self.config = config
+        fixed_cfg = config.get("fixed_point", {})
         self.fixed_point_solver = FixedPointSolver(
-            max_iterations=config["fixed_point"]["max_iterations"],
-            tolerance=config["fixed_point"]["tolerance"],
+            max_iterations=fixed_cfg.get("max_iterations", 20),
+            tolerance=fixed_cfg.get("tolerance", 1e-6),
+            damping_factor=fixed_cfg.get("damping_factor", 0.3),
+            eps=fixed_cfg.get("eps", 1e-3),
         )
-        self.grid_search = GridSearchOptimizer(
-            lambda_grid=config["fixed_point"]["lambda_grid"],
-            num_groups=config["groups"]["num_groups"],
-        )
+        lambda_grid = fixed_cfg.get("lambda_grid", np.linspace(-2.0, 2.0, 9))
+        num_groups = config["groups"]["num_groups"]
+        self.grid_search = GridSearchOptimizer(lambda_grid, num_groups)
 
     def optimize(
         self,
@@ -317,37 +224,29 @@ class PluginOptimizer:
         targets: torch.Tensor,
         group_ids: torch.Tensor,
         group_info: Dict,
+        metric: str = "balanced_selective_error",
     ) -> Tuple[Dict[int, float], Dict[int, float]]:
-        """Optimize α and μ parameters"""
-
-        rejection_cost = self.config["rejection_cost"]
-
-        # Grid search for optimal λ (and thus μ)
-        best_alpha, best_mu, best_lambda = self.grid_search.optimize(
-            probs, targets, group_ids, rejection_cost, group_info
+        rejection_cost = float(self.config["rejection_cost"])
+        alpha, mu, _ = self.grid_search.optimize(
+            probs,
+            targets,
+            group_ids,
+            rejection_cost,
+            group_info,
+            self.fixed_point_solver,
+            metric,
         )
-
-        logging.info(f"Optimized parameters:")
-        logging.info(f"alpha: {best_alpha}")
-        logging.info(f"mu: {best_mu}")
-        logging.info(f"lambda: {best_lambda}")
-
-        return best_alpha, best_mu
+        return alpha, mu
 
     def create_plugin_rule(
         self, alpha: Dict[int, float], mu: Dict[int, float], group_info: Dict
     ) -> PluginRule:
-        """Create plugin rule with optimized parameters"""
         return PluginRule(alpha, mu, self.config["rejection_cost"], group_info)
 
 
 def compute_group_ids(targets: torch.Tensor, group_info: Dict) -> torch.Tensor:
-    """Compute group IDs for targets"""
-    class_to_group = group_info["class_to_group"]
-    group_ids = torch.tensor([class_to_group[target.item()] for target in targets]).to(
-        targets.device
-    )
-    return group_ids
+    class_to_group = _sorted_class_to_group(group_info["class_to_group"])
+    return class_to_group.to(targets.device)[targets]
 
 
 def evaluate_plugin_rule(
@@ -356,53 +255,41 @@ def evaluate_plugin_rule(
     targets: torch.Tensor,
     group_ids: torch.Tensor,
 ) -> Dict[str, float]:
-    """Evaluate plugin rule performance"""
     predictions, rejections = plugin_rule.forward(probs)
     accept_mask = rejections == 0
 
-    results = {}
-
-    # Overall metrics
+    results: Dict[str, float] = {}
     if accept_mask.sum() > 0:
-        accepted_correct = (predictions[accept_mask] == targets[accept_mask]).float()
-        results["selective_accuracy"] = accepted_correct.mean().item()
-        results["selective_error"] = 1.0 - results["selective_accuracy"]
+        accuracy = (predictions[accept_mask] == targets[accept_mask]).float().mean().item()
+        results["selective_accuracy"] = accuracy
+        results["selective_error"] = 1.0 - accuracy
     else:
         results["selective_accuracy"] = 0.0
         results["selective_error"] = 1.0
 
-    results["coverage"] = accept_mask.float().mean().item()
-    results["rejection_rate"] = 1.0 - results["coverage"]
+    coverage = accept_mask.float().mean().item()
+    results["coverage"] = coverage
+    results["rejection_rate"] = 1.0 - coverage
 
-    # Group-wise metrics
-    unique_groups = torch.unique(group_ids)
-    group_errors = []
-    group_coverage = []
-
-    for group_id in unique_groups:
-        group_mask = group_ids == group_id
-        group_accept_mask = group_mask & accept_mask
-
-        # Group coverage
-        if group_mask.sum() > 0:
-            group_cov = group_accept_mask.float().sum() / group_mask.float().sum()
-            group_coverage.append(group_cov.item())
+    group_errors: List[float] = []
+    group_coverages: List[float] = []
+    for group in torch.unique(group_ids):
+        mask = group_ids == group
+        accept_group = mask & accept_mask
+        if mask.sum() > 0:
+            group_coverages.append(accept_group.float().sum().item() / mask.float().sum().item())
         else:
-            group_coverage.append(0.0)
-
-        # Group error
-        if group_accept_mask.sum() > 0:
-            group_correct = (
-                predictions[group_accept_mask] == targets[group_accept_mask]
-            ).float()
-            group_error = 1.0 - group_correct.mean()
-            group_errors.append(group_error.item())
+            group_coverages.append(0.0)
+        if accept_group.sum() > 0:
+            error = 1.0 - (
+                predictions[accept_group] == targets[accept_group]
+            ).float().mean().item()
+            group_errors.append(error)
         else:
-            group_errors.append(1.0)  # No accepted samples
+            group_errors.append(1.0)
 
-    results["balanced_selective_error"] = np.mean(group_errors)
-    results["worst_group_error"] = max(group_errors) if group_errors else 1.0
-    results["group_coverage"] = group_coverage
+    results["balanced_selective_error"] = float(np.mean(group_errors))
+    results["worst_group_error"] = float(np.max(group_errors))
+    results["group_coverage"] = group_coverages
     results["group_errors"] = group_errors
-
     return results

--- a/pb_gse/scripts/run_experiment.py
+++ b/pb_gse/scripts/run_experiment.py
@@ -86,9 +86,12 @@ def run_inference_and_evaluation(config: dict, args):
     gating_checkpoint = torch.load(gating_path, map_location=device)
 
     # Reconstruct gating model (simplified)
-    input_dim = 100  # This should match the actual feature dimension
-    num_models = len(model_names)
-    gating_model = PACBayesGating(input_dim, num_models, config).to(device)
+    gating_cfg = config["gating"]
+    input_dim = gating_checkpoint.get("input_dim")
+    num_models = gating_checkpoint.get("num_models", len(model_names))
+    if input_dim is None:
+        raise KeyError("Gating checkpoint missing 'input_dim'")
+    gating_model = PACBayesGating(input_dim, num_models, gating_cfg, group_info).to(device)
     gating_model.load_state_dict(gating_checkpoint["model_state_dict"])
 
     # Create inference engine

--- a/pb_gse/scripts/train_gating_pacbayes.py
+++ b/pb_gse/scripts/train_gating_pacbayes.py
@@ -1,392 +1,274 @@
-"""
-Training script for gating network using PAC-Bayes bound
-"""
-
-import os
-import sys
-import torch
-import torch.nn as nn
-import torch.optim as optim
-from torch.utils.data import DataLoader, TensorDataset
-import yaml
 import argparse
 import logging
-import numpy as np
+import os
+import sys
 from pathlib import Path
-from typing import List, Tuple, Dict
+from typing import Dict, List, Optional, Tuple
 
-# Add parent directory to path
+import torch
+import torch.nn.functional as F
+from torch.utils.data import DataLoader, TensorDataset
+import torch.optim as optim
+import yaml
+
 sys.path.append(str(Path(__file__).parent.parent))
 
-from data.datasets import get_dataset_and_splits
-from models.gating import PACBayesGating, FeatureExtractor, BalancedLinearLoss
-from models.plugin_rule import PluginOptimizer, compute_group_ids
+from data.datasets import get_dataset_and_splits  # type: ignore
+from models.gating import BalancedLinearLoss, FeatureExtractor, PACBayesGating
+from models.plugin_rule import PluginOptimizer
 
 
-def setup_logging(log_dir: str):
-    """Setup logging configuration"""
+def setup_logging(log_dir: str) -> None:
     os.makedirs(log_dir, exist_ok=True)
     log_file = os.path.join(log_dir, "gating_training.log")
-
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s - %(levelname)s - %(message)s",
         handlers=[logging.FileHandler(log_file), logging.StreamHandler()],
+        force=True,
     )
 
 
-def load_model_probs(probs_dir: str, model_names: list, split: str = "train") -> tuple:
-    """Load model probabilities for ensemble"""
-    model_probs_list = []
-    targets = None
-
-    for model_name in model_names:
-        prob_path = os.path.join(probs_dir, model_name, f"{split}.pth")
-        if not os.path.exists(prob_path):
-            raise FileNotFoundError(f"Probabilities not found: {prob_path}")
-
-        data = torch.load(prob_path)
-        probs = data["probs"]
-        model_probs_list.append(probs)
-
-        # Use targets from first model (should be same for all)
+def load_model_probs(probs_dir: str, model_names: List[str], split: str) -> Tuple[List[torch.Tensor], torch.Tensor]:
+    probs: List[torch.Tensor] = []
+    targets: Optional[torch.Tensor] = None
+    for name in model_names:
+        path = os.path.join(probs_dir, name, f"{split}.pth")
+        if not os.path.exists(path):
+            raise FileNotFoundError(f"Probability file not found: {path}")
+        data = torch.load(path)
+        probs.append(data["probs"].float())
         if targets is None:
-            targets = data["targets"]
-
-    return model_probs_list, targets
+            targets = data["targets"].long()
+    assert targets is not None
+    return probs, targets
 
 
 def create_gating_dataset(
-    model_probs_list: list, targets: torch.Tensor, group_info: dict, config: dict
-) -> TensorDataset:
-    """Create dataset for gating network training"""
+    model_probs: List[torch.Tensor],
+    targets: torch.Tensor,
+    group_info: Dict,
+    config: Dict,
+    include_group_onehot: bool = True,
+) -> Tuple[TensorDataset, int, int]:
+    gating_cfg = config["gating"]
+    extractor = FeatureExtractor(gating_cfg, group_info)
+    stacked_probs = torch.stack(model_probs, dim=1)  # [N, M, C]
 
-    # Extract features
-    feature_extractor = FeatureExtractor(config["gating"], group_info)
-
-    # Create group one-hot encodings
     num_groups = config["plugin"]["groups"]["num_groups"]
     class_to_group = group_info["class_to_group"]
+    group_ids = torch.tensor([int(class_to_group[int(t.item())]) for t in targets], dtype=torch.long)
+    group_onehot = None
+    if include_group_onehot and getattr(extractor, "use_group_onehot", False):
+        group_onehot = F.one_hot(group_ids, num_classes=num_groups).float()
 
-    group_ids = torch.tensor([class_to_group[target.item()] for target in targets])
-    group_onehot = torch.nn.functional.one_hot(
-        group_ids, num_classes=num_groups
-    ).float()
-
-    # Extract features
-    features = feature_extractor.extract(model_probs_list, group_onehot)
-
-    return TensorDataset(features, targets, group_ids), features.size(1)
+    features = extractor.extract(stacked_probs, group_onehot)
+    dataset = TensorDataset(features, stacked_probs, targets, group_ids)
+    input_dim = features.size(1)
+    num_classes = stacked_probs.size(-1)
+    return dataset, input_dim, num_classes
 
 
-def train_gating_epoch(
-    gating_model,
-    dataloader,
-    optimizer,
-    alpha,
-    mu,
-    rejection_cost,
-    group_info,
-    config,
-    device,
-    epoch=0,
-):
-    """Train gating network for one epoch"""
+def train_epoch(
+    gating_model: PACBayesGating,
+    dataloader: DataLoader,
+    optimizer: optim.Optimizer,
+    loss_fn: BalancedLinearLoss,
+    delta: float,
+    device: torch.device,
+    mc_samples: int,
+) -> Tuple[float, float]:
     gating_model.train()
-
-    total_loss = 0.0
+    total_raw = 0.0
     total_bound = 0.0
+    n_batches = 0
+    loss_fn = loss_fn.to(device)
     n_samples = len(dataloader.dataset)
 
-    # Create balanced linear loss
-    balanced_loss_fn = BalancedLinearLoss(alpha, mu, rejection_cost, group_info)
-
-    for batch_idx, (features, targets, group_ids) in enumerate(dataloader):
+    for features, model_probs, targets, group_ids in dataloader:
         features = features.to(device)
+        model_probs = model_probs.to(device)
         targets = targets.to(device)
         group_ids = group_ids.to(device)
 
         optimizer.zero_grad()
+        raw_losses: List[torch.Tensor] = []
 
-        # Forward pass through gating
-        if config["gating"]["pac_bayes"]["method"] == "gaussian":
-            # Monte Carlo sampling for Gaussian posterior
-            num_samples = 5  # Number of MC samples
-            batch_losses = []
+        samples = mc_samples if gating_model.is_gaussian else 1
+        for _ in range(samples):
+            gating_weights = gating_model(features, sample=gating_model.is_gaussian)
+            ensemble = gating_model.compute_ensemble_probs(model_probs, gating_weights)
+            raw_loss, _ = loss_fn(ensemble, targets, group_ids)
+            raw_losses.append(raw_loss)
 
-            for _ in range(num_samples):
-                gating_weights = gating_model.forward(features)
-
-                # Reconstruct model probabilities (dummy for this batch)
-                # In practice, you'd need to store and pass the actual model probs
-                # For now, we'll use a simplified version
-                batch_size, num_classes = features.size(0), 10  # Assuming CIFAR-10
-                dummy_probs = [
-                    torch.softmax(torch.randn(batch_size, num_classes), dim=1).to(
-                        device
-                    )
-                    for _ in range(gating_model.num_models)
-                ]
-
-                # Compute ensemble probabilities
-                ensemble_probs = gating_model.compute_ensemble_probs(
-                    dummy_probs, gating_weights
-                )
-
-                # Compute balanced linear loss
-                loss = balanced_loss_fn(ensemble_probs, targets, group_ids)
-                batch_losses.append(loss)
-
-            # Average over MC samples
-            empirical_loss = torch.stack(batch_losses).mean()
-
-        else:
-            # Deterministic gating
-            gating_weights = gating_model.forward(features)
-
-            # Dummy ensemble probabilities (replace with actual computation)
-            batch_size, num_classes = features.size(0), 10
-            dummy_probs = [
-                torch.softmax(torch.randn(batch_size, num_classes), dim=1).to(device)
-                for _ in range(gating_model.num_models)
-            ]
-
-            ensemble_probs = gating_model.compute_ensemble_probs(
-                dummy_probs, gating_weights
-            )
-            empirical_loss = balanced_loss_fn(ensemble_probs, targets, group_ids)
-
-        # Compute PAC-Bayes bound
-        delta = config["gating"]["confidence_threshold"]
-        pac_bayes_bound = gating_model.pac_bayes_bound(empirical_loss, n_samples, delta)
-
-        # Backward pass
-        pac_bayes_bound.backward()
+        empirical_risk = torch.stack(raw_losses).mean()
+        bound = gating_model.pac_bayes_bound(empirical_risk, n_samples, delta, loss_fn.L_alpha)
+        bound.backward()
         optimizer.step()
 
-        total_loss += empirical_loss.item()
-        total_bound += pac_bayes_bound.item()
+        total_raw += empirical_risk.item()
+        total_bound += bound.item()
+        n_batches += 1
 
-    avg_loss = total_loss / len(dataloader)
-    avg_bound = total_bound / len(dataloader)
-
-    return avg_loss, avg_bound
+    return total_raw / max(n_batches, 1), total_bound / max(n_batches, 1)
 
 
-def validate_gating(
-    gating_model, dataloader, alpha, mu, rejection_cost, group_info, device
-):
-    """Validate gating network"""
+def evaluate(
+    gating_model: PACBayesGating,
+    dataloader: DataLoader,
+    loss_fn: BalancedLinearLoss,
+    device: torch.device,
+) -> Tuple[float, float]:
     gating_model.eval()
-
-    total_loss = 0.0
-    correct = 0
-    total = 0
-
-    balanced_loss_fn = BalancedLinearLoss(alpha, mu, rejection_cost, group_info)
+    total_raw = 0.0
+    total_accuracy = 0.0
+    total_samples = 0
+    loss_fn = loss_fn.to(device)
 
     with torch.no_grad():
-        for features, targets, group_ids in dataloader:
+        for features, model_probs, targets, group_ids in dataloader:
             features = features.to(device)
+            model_probs = model_probs.to(device)
             targets = targets.to(device)
             group_ids = group_ids.to(device)
 
-            gating_weights = gating_model.forward(features)
+            gating_weights = gating_model(features, sample=False)
+            ensemble = gating_model.compute_ensemble_probs(model_probs, gating_weights)
+            raw_loss, _, predictions, accept_mask = loss_fn(ensemble, targets, group_ids, return_details=True)
+            total_raw += raw_loss.item() * targets.size(0)
+            if accept_mask.sum() > 0:
+                acc = (predictions[accept_mask] == targets[accept_mask]).float().mean().item()
+            else:
+                acc = 0.0
+            total_accuracy += acc * targets.size(0)
+            total_samples += targets.size(0)
 
-            # Dummy computation (replace with actual)
-            batch_size, num_classes = features.size(0), 10
-            dummy_probs = [
-                torch.softmax(torch.randn(batch_size, num_classes), dim=1).to(device)
-                for _ in range(gating_model.num_models)
-            ]
-
-            ensemble_probs = gating_model.compute_ensemble_probs(
-                dummy_probs, gating_weights
-            )
-            loss = balanced_loss_fn(ensemble_probs, targets, group_ids)
-
-            total_loss += loss.item()
-
-            # Simple accuracy computation
-            _, predicted = ensemble_probs.max(1)
-            total += targets.size(0)
-            correct += predicted.eq(targets).sum().item()
-
-    avg_loss = total_loss / len(dataloader)
-    accuracy = 100.0 * correct / total
-
-    return avg_loss, accuracy
+    return total_raw / max(total_samples, 1), total_accuracy / max(total_samples, 1)
 
 
-def main():
-    parser = argparse.ArgumentParser(description="Train gating network with PAC-Bayes")
-    parser.add_argument("--config", type=str, required=True, help="Config file path")
-    parser.add_argument(
-        "--probs_dir",
-        type=str,
-        required=True,
-        help="Directory with model probabilities",
-    )
-    parser.add_argument(
-        "--save_dir", type=str, default="./outputs", help="Save directory"
-    )
-    parser.add_argument("--device", type=str, default="cuda", help="Device to use")
-
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train PB-GSE gating network")
+    parser.add_argument("--config", type=str, required=True, help="Path to experiment config")
+    parser.add_argument("--probs_dir", type=str, required=True, help="Directory of calibrated probabilities")
+    parser.add_argument("--save_dir", type=str, default="./outputs", help="Output directory")
+    parser.add_argument("--device", type=str, default="cuda", help="Device identifier")
     args = parser.parse_args()
 
-    # Load config
     with open(args.config, "r") as f:
         config = yaml.safe_load(f)
 
-    # Setup
     device = torch.device(args.device if torch.cuda.is_available() else "cpu")
-
-    # Setup logging
     setup_logging(os.path.join(args.save_dir, "logs"))
-    logging.info("Starting gating network training")
 
-    # Load dataset for group info
+    logging.info("Loading dataset metadata")
     _, group_info = get_dataset_and_splits(config)
 
-    # Model names (should match trained models)
     model_names = ["cRT", "LDAM_DRW", "CB_Focal"]
-
-    # Load model probabilities
-    logging.info("Loading model probabilities...")
+    logging.info("Loading model probabilities")
     train_probs, train_targets = load_model_probs(args.probs_dir, model_names, "train")
     val_probs, val_targets = load_model_probs(args.probs_dir, model_names, "val")
     cal_probs, cal_targets = load_model_probs(args.probs_dir, model_names, "cal")
 
-    # Create gating datasets
-    train_dataset, input_dim = create_gating_dataset(
-        train_probs, train_targets, group_info, config
-    )
-    val_dataset, _ = create_gating_dataset(val_probs, val_targets, group_info, config)
-    cal_dataset, _ = create_gating_dataset(cal_probs, cal_targets, group_info, config)
+    logging.info("Creating gating datasets")
+    train_dataset, input_dim, num_classes = create_gating_dataset(train_probs, train_targets, group_info, config)
+    val_dataset, _, _ = create_gating_dataset(val_probs, val_targets, group_info, config)
+    cal_dataset, _, _ = create_gating_dataset(cal_probs, cal_targets, group_info, config, include_group_onehot=False)
 
-    # Create data loaders
-    train_loader = DataLoader(
-        train_dataset,
-        batch_size=config["gating"]["batch_size"],
-        shuffle=True,
-        num_workers=4,
-    )
+    batch_size = config["gating"].get("batch_size", 512)
+    train_loader = DataLoader(train_dataset, batch_size=batch_size, shuffle=True, num_workers=0)
+    val_loader = DataLoader(val_dataset, batch_size=batch_size, shuffle=False, num_workers=0)
+    cal_loader = DataLoader(cal_dataset, batch_size=batch_size, shuffle=False, num_workers=0)
 
-    val_loader = DataLoader(
-        val_dataset,
-        batch_size=config["gating"]["batch_size"],
-        shuffle=False,
-        num_workers=4,
-    )
-
-    cal_loader = DataLoader(
-        cal_dataset,
-        batch_size=config["gating"]["batch_size"],
-        shuffle=False,
-        num_workers=4,
-    )
-
-    # Create gating model
     num_models = len(model_names)
-    gating_model = PACBayesGating(input_dim, num_models, config).to(device)
-
-    # Create optimizer
-    if config["gating"]["pac_bayes"]["method"] == "gaussian":
-        params = [gating_model.posterior.mu, gating_model.posterior.log_sigma]
+    gating_model = PACBayesGating(input_dim, num_models, config["gating"], group_info).to(device)
+    if gating_model.is_gaussian:
+        params = list(gating_model.posterior.parameters())
     else:
-        params = gating_model.gating_net.parameters()
+        params = gating_model.parameters()
+    optimizer = optim.Adam(params, lr=config["gating"].get("lr", 1e-3))
 
-    optimizer = optim.Adam(params, lr=config["gating"]["lr"])
-
-    # Initialize plugin rule optimizer
     plugin_optimizer = PluginOptimizer(config["plugin"])
 
-    # Get initial α, μ parameters using calibration set
-    logging.info("Computing initial α, μ parameters...")
-    cal_features = cal_dataset.tensors[0].to(device)
-    cal_targets = cal_dataset.tensors[1].to(device)
-    cal_group_ids = cal_dataset.tensors[2].to(device)
+    logging.info("Initialising plug-in parameters from calibration set")
+    cal_features, cal_probs_tensor, cal_targets_tensor, cal_group_ids = cal_dataset.tensors
+    cal_features = cal_features.to(device)
+    cal_probs_tensor = cal_probs_tensor.to(device)
+    cal_targets_tensor = cal_targets_tensor.to(device)
+    cal_group_ids = cal_group_ids.to(device)
 
-    # Dummy ensemble probabilities for initial optimization
     with torch.no_grad():
-        gating_weights = gating_model.forward(cal_features)
-        dummy_probs = [
-            torch.softmax(torch.randn(cal_features.size(0), 10), dim=1).to(device)
-            for _ in range(num_models)
-        ]
-        ensemble_probs = gating_model.compute_ensemble_probs(
-            dummy_probs, gating_weights
-        )
+        cal_weights = gating_model(cal_features, sample=False)
+        cal_ensemble = gating_model.compute_ensemble_probs(cal_probs_tensor, cal_weights)
+    alpha, mu = plugin_optimizer.optimize(cal_ensemble, cal_targets_tensor, cal_group_ids, group_info)
+    loss_fn = BalancedLinearLoss(alpha, mu, config["plugin"]["rejection_cost"], group_info)
 
-    alpha, mu = plugin_optimizer.optimize(
-        ensemble_probs, cal_targets, cal_group_ids, group_info
-    )
-    rejection_cost = config["plugin"]["rejection_cost"]
+    epochs = config["gating"].get("epochs", 30)
+    delta = config["gating"].get("confidence_threshold", 0.05)
+    mc_samples = int(config["gating"].get("pac_bayes", {}).get("mc_samples", 1))
 
-    logging.info(f"Initial α: {alpha}")
-    logging.info(f"Initial μ: {mu}")
-
-    # Training loop
-    epochs = config["gating"]["epochs"]
-    best_val_loss = float("inf")
+    best_val = float("inf")
     patience = config["gating"].get("patience", 5)
     patience_counter = 0
 
     for epoch in range(epochs):
-        # Train
-        train_loss, train_bound = train_gating_epoch(
-            gating_model,
-            train_loader,
-            optimizer,
-            alpha,
-            mu,
-            rejection_cost,
-            group_info,
-            config,
-            device,
-            epoch,
+        train_raw, train_bound = train_epoch(gating_model, train_loader, optimizer, loss_fn, delta, device, mc_samples)
+        val_loss, val_acc = evaluate(gating_model, val_loader, loss_fn, device)
+
+        logging.info(
+            "Epoch %d/%d - train risk: %.4f, bound: %.4f, val risk: %.4f, val selective acc: %.4f",
+            epoch + 1,
+            epochs,
+            train_raw,
+            train_bound,
+            val_loss,
+            val_acc,
         )
 
-        # Validate
-        val_loss, val_acc = validate_gating(
-            gating_model, val_loader, alpha, mu, rejection_cost, group_info, device
-        )
-
-        logging.info(f"Epoch {epoch + 1}/{epochs}:")
-        logging.info(f"  Train Loss: {train_loss:.4f}, Train Bound: {train_bound:.4f}")
-        logging.info(f"  Val Loss: {val_loss:.4f}, Val Acc: {val_acc:.2f}%")
-
-        # Early stopping
-        if val_loss < best_val_loss:
-            best_val_loss = val_loss
+        if val_loss < best_val - 1e-5:
+            best_val = val_loss
             patience_counter = 0
-
-            # Save best model
             save_path = os.path.join(args.save_dir, "gating", "best_gating.pth")
             os.makedirs(os.path.dirname(save_path), exist_ok=True)
-
             torch.save(
                 {
                     "model_state_dict": gating_model.state_dict(),
                     "optimizer_state_dict": optimizer.state_dict(),
                     "epoch": epoch,
-                    "val_loss": val_loss,
                     "alpha": alpha,
                     "mu": mu,
+                    "input_dim": input_dim,
+                    "num_models": num_models,
                     "config": config,
                 },
                 save_path,
             )
-
-            logging.info(f"Saved best model with val_loss: {val_loss:.4f}")
+            logging.info("Saved gating model to %s", save_path)
         else:
             patience_counter += 1
+            if patience_counter >= patience:
+                logging.info("Early stopping triggered")
+                break
 
-        if patience_counter >= patience:
-            logging.info(f"Early stopping at epoch {epoch + 1}")
-            break
+    logging.info("Recomputing plug-in parameters with final model")
+    with torch.no_grad():
+        cal_weights = gating_model(cal_features, sample=False)
+        cal_ensemble = gating_model.compute_ensemble_probs(cal_probs_tensor, cal_weights)
+    alpha, mu = plugin_optimizer.optimize(cal_ensemble, cal_targets_tensor, cal_group_ids, group_info)
 
-    logging.info("Gating network training completed")
+    final_path = os.path.join(args.save_dir, "gating", "final_gating.pth")
+    os.makedirs(os.path.dirname(final_path), exist_ok=True)
+    torch.save(
+        {
+            "model_state_dict": gating_model.state_dict(),
+            "alpha": alpha,
+            "mu": mu,
+            "input_dim": input_dim,
+            "num_models": num_models,
+            "config": config,
+        },
+        final_path,
+    )
+    logging.info("Saved final gating checkpoint to %s", final_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- rebuild the gating module around a reusable feature extractor, diagonal Gaussian posterior, and balanced linear loss helper
- overhaul the plug-in rule, inference utilities, and metrics to align with the PB-GSE formulation and remove broken placeholders
- rewrite the PAC-Bayes gating training script to consume real calibrated probabilities and save the metadata needed by the experiment runner

## Testing
- python -m compileall pb_gse

------
https://chatgpt.com/codex/tasks/task_e_68caf21b3bb483259f59be1c3c6edb4d